### PR TITLE
Single contact email and Calendly-only scheduling (no public forms)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ NEXT_PUBLIC_SITE_URL=https://www.openhousemarketplace.com
 # Resend (optional): contact form + open house sign-in notifications
 # RESEND_API_KEY=
 # RESEND_FROM_EMAIL=noreply@openhousemarketplace.com
-# RESEND_NOTIFY_EMAIL=jan@openhousemarketplace.com
+# RESEND_NOTIFY_EMAIL=DrJanSells@OpenHouseMarketplace.com
 
 # Optional: override shared Google My Maps embed URL (default in lib/google-my-maps.ts)
 # NEXT_PUBLIC_GOOGLE_MY_MAPS_EMBED_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Site update (June 2026)
 
+* **Contact:** Single public email **DrJanSells@OpenHouseMarketplace.com** in `config/gbp.ts` (NAP, footer, schema, legal pages). No public forms—scheduling via Calendly only; `/api/contact`, `/api/leads` POST, and open-house sign-in POST return 410.
 * **Vercel deploy audit:** Document repo transfer (LetMeHelpYouREALTY vs DrJanDuffy), correct `prj_UH4vlCl7EkB4ipEIvu7kflQN3p2E`, stale production SHA; GitHub Actions guard for drjanduffy project ID.
 * **GSC canonical:** `/index`, `/index/`, `/index.html` → **301** to `/` (Vercel edge, `next.config`, middleware, `app/index/route.ts`) — fixes “Duplicate without user-selected canonical”.
 * **GSC indexing:** `PageIndexingEnhancement` + `config/indexing-pages.ts` (FAQs, speakable summaries, internal links) on 28 discovered URLs; privacy/terms set to `index`; sitemap `lastModified`; home-buying HowTo.

--- a/app/api/ai-crawl/route.ts
+++ b/app/api/ai-crawl/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { GBP } from '@/config/gbp'
 import { getSiteUrl } from '@/lib/site'
 
 export async function GET() {
@@ -49,7 +50,7 @@ export async function GET() {
     ],
     contact: {
       phone: '+1-702-200-3422',
-      email: 'jan@openhousemarketplace.com'
+      email: GBP.email
     },
     structuredData: {
       organization: true,

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,58 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { sendContactFormEmail } from '@/lib/email'
+import { NextResponse } from 'next/server'
+import { CALENDLY_OPEN_HOUSE_TOUR_URL } from '@/lib/calendly'
+import { GBP } from '@/config/gbp'
 
-interface ContactData {
-  name: string
-  email: string
-  phone: string
-  subject: string
-  message: string
-  contactType: 'buyer' | 'seller' | 'investor' | 'general'
-  toEmail: string
-}
-
-function isValidContactData(obj: unknown): obj is ContactData {
-  return (
-    !!obj &&
-    typeof obj === 'object' &&
-    typeof (obj as ContactData).name === 'string' &&
-    typeof (obj as ContactData).email === 'string' &&
-    typeof (obj as ContactData).phone === 'string' &&
-    typeof (obj as ContactData).subject === 'string' &&
-    typeof (obj as ContactData).message === 'string' &&
-    typeof (obj as ContactData).contactType === 'string' &&
-    typeof (obj as ContactData).toEmail === 'string' &&
-    ['buyer', 'seller', 'investor', 'general'].includes((obj as ContactData).contactType)
+/** Public contact forms are disabled; scheduling uses Calendly only. */
+export async function POST() {
+  return NextResponse.json(
+    {
+      error: 'Contact forms are not available. Schedule online or email us directly.',
+      scheduleUrl: CALENDLY_OPEN_HOUSE_TOUR_URL,
+      email: GBP.email,
+    },
+    { status: 410 }
   )
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    const data = await request.json()
-
-    if (!isValidContactData(data)) {
-      return NextResponse.json({ error: 'Invalid contact data format' }, { status: 400 })
-    }
-
-    const { name, email, phone, subject, message, contactType, toEmail } = data
-
-    const emailResult = await sendContactFormEmail(
-      { name, email, phone, subject, message, contactType },
-      toEmail
-    )
-
-    if (!emailResult.success) {
-      console.error('Contact form email failed:', emailResult.error)
-      return NextResponse.json({ error: 'Failed to send contact message' }, { status: 500 })
-    }
-
-    return NextResponse.json({
-      success: true,
-      message: 'Contact message sent successfully',
-      toEmail,
-    })
-  } catch (error) {
-    console.error('Error processing contact:', error)
-    return NextResponse.json({ error: 'Failed to send contact message' }, { status: 500 })
-  }
 }

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,175 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import followupBossService from '@/lib/followupboss-service'
+import { CALENDLY_OPEN_HOUSE_TOUR_URL } from '@/lib/calendly'
+import { GBP } from '@/config/gbp'
 
-interface LeadData {
-  firstName: string
-  lastName: string
-  email: string
-  phone: string
-  propertyId?: string
-  propertyAddress?: string
-  source?: string
-  registrationType: 'light' | 'full'
-  buyingTimeframe?: string
-  priceRange?: string
-  prequalified?: string
-  currentlyWorking?: string
-  notes?: string
-}
-
-// Type guard for lead data
-function isValidLeadData(obj: any): obj is LeadData {
-  return obj &&
-    typeof obj.firstName === 'string' &&
-    typeof obj.lastName === 'string' &&
-    typeof obj.email === 'string' &&
-    typeof obj.phone === 'string' &&
-    typeof obj.registrationType === 'string' &&
-    (obj.registrationType === 'light' || obj.registrationType === 'full')
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    console.log('API route called - processing lead submission')
-    const data = await request.json()
-    console.log('Received data:', JSON.stringify(data, null, 2))
-    
-    if (!isValidLeadData(data)) {
-      console.error('Invalid lead data format:', data)
-      return NextResponse.json(
-        { error: 'Invalid lead data format' },
-        { status: 400 }
-      )
-    }
-
-    const { 
-      firstName,
-      lastName,
-      email,
-      phone,
-      propertyId,
-      propertyAddress,
-      source,
-      registrationType,
-      buyingTimeframe,
-      priceRange,
-      prequalified,
-      currentlyWorking,
-      notes
-    } = data
-
-    console.log('Processing lead for:', email, 'in neighborhood:', propertyAddress)
-
-    // Determine tags based on form data
-    const tags = ['Website Lead']
-    
-    if (registrationType === 'full') {
-      tags.push('Full Registration')
-      
-      if (buyingTimeframe === 'Immediately' || buyingTimeframe === 'Within 3 months') {
-        tags.push('Hot Lead')
-      } else if (buyingTimeframe === 'Within 6 months') {
-        tags.push('Warm Lead')
-      } else {
-        tags.push('Long Term')
-      }
-
-      if (prequalified === 'Yes') {
-        tags.push('Pre-Qualified')
-      }
-
-      if (currentlyWorking === 'No') {
-        tags.push('Unrepresented')
-      }
-    } else {
-      tags.push('Quick Registration')
-    }
-
-    // Create or update lead in FollowupBoss
-    const leadData = {
-      firstName,
-      lastName,
-      email,
-      phone,
-      propertyId,
-      propertyAddress,
-      source,
-      tags,
-      notes,
-      customFields: {
-        registrationType,
-        buyingTimeframe,
-        priceRange,
-        prequalified,
-        currentlyWorking
-      }
-    }
-
-    console.log('Calling followupBossService.createOrUpdateLead...')
-    const result = await followupBossService.createOrUpdateLead(leadData)
-    console.log('FollowUpBoss service result:', result)
-    
-    if ('error' in result && result.error) {
-      console.error('FollowUpBoss service error:', result.error)
-      
-      // If FollowUpBoss is not configured, still return success but log the data
-      if (result.error.includes('not configured')) {
-        console.log('FollowUpBoss not configured, but lead data received:', {
-          firstName,
-          lastName,
-          email,
-          phone,
-          propertyAddress,
-          source,
-          registrationType
-        })
-        return NextResponse.json({ 
-          success: true, 
-          message: 'Lead received (FollowUpBoss not configured)',
-          leadData: { firstName, lastName, email, phone, propertyAddress }
-        })
-      }
-      
-      return NextResponse.json(
-        { error: result.error },
-        { status: 500 }
-      )
-    }
-
-    console.log('Lead created/updated successfully')
-
-    // Track property interaction
-    try {
-      await followupBossService.trackPropertyInteraction({
-        propertyId: propertyId || 'unknown',
-        type: 'register',
-        timestamp: new Date().toISOString(),
-        leadEmail: email
-      })
-      console.log('Property interaction tracked')
-    } catch (interactionError) {
-      console.warn('Failed to track property interaction:', interactionError)
-    }
-
-    // Set up automated alerts if full registration
-    if (registrationType === 'full') {
-      try {
-        await followupBossService.setupAutomation(email, propertyId || 'unknown')
-        console.log('Automation setup completed')
-      } catch (automationError) {
-        console.warn('Failed to setup automation:', automationError)
-      }
-    }
-
-    return NextResponse.json({ success: true })
-
-  } catch (error) {
-    console.error('Error processing lead:', error)
-    return NextResponse.json(
-      { error: 'Failed to process registration' },
-      { status: 500 }
-    )
-  }
+/** Lead capture forms are disabled; use Calendly for scheduling. */
+export async function POST() {
+  return NextResponse.json(
+    {
+      error: 'Lead forms are not available. Schedule online with Calendly.',
+      scheduleUrl: CALENDLY_OPEN_HOUSE_TOUR_URL,
+      email: GBP.email,
+    },
+    { status: 410 }
+  )
 }
 
 interface InteractionData {
@@ -178,42 +21,37 @@ interface InteractionData {
   interactionType: 'view' | 'save' | 'schedule' | 'register'
 }
 
-function isValidInteractionData(obj: any): obj is InteractionData {
-  return obj &&
-    typeof obj.email === 'string' &&
-    typeof obj.propertyId === 'string' &&
-    typeof obj.interactionType === 'string' &&
-    ['view', 'save', 'schedule', 'register'].includes(obj.interactionType)
+function isValidInteractionData(obj: unknown): obj is InteractionData {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    typeof (obj as InteractionData).email === 'string' &&
+    typeof (obj as InteractionData).propertyId === 'string' &&
+    typeof (obj as InteractionData).interactionType === 'string' &&
+    ['view', 'save', 'schedule', 'register'].includes((obj as InteractionData).interactionType)
+  )
 }
 
 export async function PUT(request: NextRequest) {
   try {
     const data = await request.json()
-    
+
     if (!isValidInteractionData(data)) {
-      return NextResponse.json(
-        { error: 'Invalid interaction data format' },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: 'Invalid interaction data format' }, { status: 400 })
     }
-    
+
     const { email, propertyId, interactionType } = data
 
-    // Track property interaction
     await followupBossService.trackPropertyInteraction({
       propertyId,
-      type: interactionType as 'view' | 'save' | 'schedule' | 'register',
+      type: interactionType,
       timestamp: new Date().toISOString(),
-      leadEmail: email
+      leadEmail: email,
     })
 
     return NextResponse.json({ success: true })
-
   } catch (error) {
     console.error('Error tracking interaction:', error)
-    return NextResponse.json(
-      { error: 'Failed to track interaction' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Failed to track interaction' }, { status: 500 })
   }
 }

--- a/app/api/open-house-signin/route.ts
+++ b/app/api/open-house-signin/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import crypto from 'crypto'
 import { kv } from '@vercel/kv'
-import followupBossService from '@/lib/followupboss-service'
-import {
-  parseOpenHouseSignInBody,
-  type OpenHouseSignIn,
-} from '@/lib/open-house-signin-schema'
-import { sendOpenHouseSignInEmail } from '@/lib/email'
-import { env } from '@/env.mjs'
+import type { OpenHouseSignIn } from '@/lib/open-house-signin-schema'
+import { CALENDLY_OPEN_HOUSE_TOUR_URL } from '@/lib/calendly'
+import { GBP } from '@/config/gbp'
 
-const LISTING_PREFIX = 'oh-signin:listing:'
 const SUBMISSIONS_PREFIX = 'oh-signin:submissions:'
 const SUBMISSION_PREFIX = 'oh-signin:submission:'
 const ADMIN_COOKIE = 'oh-admin-auth'
@@ -27,108 +22,16 @@ function isAdminAuthenticated(request: NextRequest): boolean {
   return !!expected && cookie === expected
 }
 
-function getClientIp(request: NextRequest): string | undefined {
-  return (
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
-    undefined
+/** Public sign-in forms are disabled; QR pages use Calendly only. */
+export async function POST() {
+  return NextResponse.json(
+    {
+      error: 'Online sign-in forms are not available. Schedule a tour with Calendly or ask the agent at the open house.',
+      scheduleUrl: CALENDLY_OPEN_HOUSE_TOUR_URL,
+      email: GBP.email,
+    },
+    { status: 410 }
   )
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json()
-    const parsed = parseOpenHouseSignInBody(body)
-    const id = crypto.randomUUID()
-    const submittedAt = new Date().toISOString()
-    const ipAddress = getClientIp(request)
-
-    const record: OpenHouseSignIn = {
-      id,
-      listingId: parsed.listingId,
-      listingAddress: parsed.listingAddress ?? '',
-      fullName: parsed.fullName,
-      email: parsed.email,
-      phone: parsed.phone,
-      workingWithAgent: parsed.workingWithAgent,
-      agentName: parsed.agentName,
-      hearAboutSource: parsed.hearAboutSource,
-      preApproved: parsed.preApproved,
-      purchaseTimeline: parsed.purchaseTimeline,
-      interestedNeighborhoods: parsed.interestedNeighborhoods,
-      submittedAt,
-      ipAddress,
-    }
-
-    try {
-      await kv.set(`${SUBMISSION_PREFIX}${id}`, record)
-      await kv.lpush(`${SUBMISSIONS_PREFIX}${parsed.listingId}`, id)
-      if (parsed.listingAddress) {
-        await kv.set(`${LISTING_PREFIX}${parsed.listingId}`, {
-          listingAddress: parsed.listingAddress,
-        })
-      }
-    } catch (kvError) {
-      console.error('KV storage error:', kvError)
-      return NextResponse.json(
-        { error: 'Storage unavailable. Please try again.' },
-        { status: 503 }
-      )
-    }
-
-    const fubResult = await followupBossService.sendRegistrationEvent({
-      fullName: parsed.fullName,
-      email: parsed.email,
-      phone: parsed.phone,
-      listingAddress: parsed.listingAddress,
-      tags: ['Open House Lead', 'Summerlin'],
-      customFields: {
-        openHouseAddress: parsed.listingAddress ?? '',
-        preApproved: parsed.preApproved,
-        timeline: parsed.purchaseTimeline,
-        hearAbout: parsed.hearAboutSource,
-        workingWithAgent: parsed.workingWithAgent ? 'Yes' : 'No',
-        agentName: parsed.agentName ?? '',
-        interestedNeighborhoods: (parsed.interestedNeighborhoods ?? []).join(', '),
-      },
-    })
-    if (!fubResult.success) {
-      console.warn('FUB Registration event failed:', fubResult.error)
-    }
-
-    if (env.RESEND_NOTIFY_EMAIL) {
-      const emailResult = await sendOpenHouseSignInEmail(
-        {
-          fullName: parsed.fullName,
-          email: parsed.email,
-          phone: parsed.phone,
-          listingAddress: parsed.listingAddress,
-          listingId: parsed.listingId,
-        },
-        env.RESEND_NOTIFY_EMAIL
-      )
-      if (!emailResult.success) {
-        console.warn('Open house sign-in email failed:', emailResult.error)
-      }
-    }
-
-    return NextResponse.json({ success: true, id })
-  } catch (err) {
-    if (err && typeof err === 'object' && 'issues' in err) {
-      const msg = (err as { issues: { message: string }[] }).issues
-        ?.map((i) => i.message)
-        .join('; ')
-      return NextResponse.json(
-        { error: msg || 'Validation failed' },
-        { status: 400 }
-      )
-    }
-    console.error('Open house sign-in API error:', err)
-    return NextResponse.json(
-      { error: 'Failed to submit sign-in' },
-      { status: 500 }
-    )
-  }
 }
 
 export async function GET(request: NextRequest) {

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import { BASE_URL, DEFAULT_OG_IMAGE_PATHS } from '@/lib/metadata-utils'
+import { GBP } from '@/config/gbp'
 
 import StructuredData from '@/components/StructuredData'
 
@@ -122,7 +123,7 @@ export default function DisclaimerPage() {
               <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">9. Contact Information</h2>
               <p>For questions about this disclaimer, please contact:</p>
               <p>
-                <strong>Email:</strong> contact@openhousemarketplace.com<br />
+                <strong>Email:</strong> {GBP.email}<br />
                 <strong>Phone:</strong> (702) 200-3422
               </p>
             </section>

--- a/app/open-house-guide/page.tsx
+++ b/app/open-house-guide/page.tsx
@@ -128,8 +128,9 @@ export default function OpenHouseGuidePage() {
             <h2 className="text-3xl font-bold text-gray-900 mb-6">What This Means for You</h2>
             <div className="space-y-4 text-gray-700 leading-relaxed">
               <p>
-                You can still freely attend <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link>. You&apos;ll
-                typically be asked to sign in (digital or paper) for security and follow-up. The
+                You can still freely attend <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link>. You may be
+                asked to sign in on paper at the door for security and follow-up, or you can{' '}
+                <Link href="/book-tour" className="text-blue-600 font-semibold hover:underline">schedule a private showing online</Link> with Dr. Jan Duffy. The
                 agent at the open house represents the seller, not you.
               </p>
               <p>

--- a/app/open-house-signin/[listingId]/page.tsx
+++ b/app/open-house-signin/[listingId]/page.tsx
@@ -3,7 +3,7 @@ import { BASE_URL, DEFAULT_OG_IMAGE_PATHS } from '@/lib/metadata-utils'
 
 import CalendlyPopupLink from '@/components/CalendlyPopupLink'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
-import OpenHouseSignInForm from '@/components/OpenHouseSignInForm'
+import { GBP } from '@/config/gbp'
 
 const LISTING_PREFIX = 'oh-signin:listing:'
 
@@ -16,13 +16,13 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { listingId } = await params
   return {
-    title: 'Open House Sign-In | Schedule a Tour | Dr. Jan Duffy',
-    description: 'Schedule a private tour with Dr. Jan Duffy or sign in at the open house. Summerlin real estate.',
+    title: 'Schedule a Tour | Open House | Dr. Jan Duffy',
+    description: 'Schedule a private tour with Dr. Jan Duffy at this Summerlin open house. Book online—no form required.',
     robots: { index: false, follow: true },
     alternates: { canonical: `${BASE_URL}/open-house-signin/${listingId}` },
     openGraph: {
-      title: 'Open House Sign-In | Schedule a Tour | Dr. Jan Duffy',
-      description: 'Schedule a private tour with Dr. Jan Duffy or sign in at the open house. Summerlin real estate.',
+      title: 'Schedule a Tour | Open House | Dr. Jan Duffy',
+      description: 'Schedule a private tour with Dr. Jan Duffy. Summerlin real estate.',
       url: `${BASE_URL}/open-house-signin/${listingId}`,
       images: [DEFAULT_OG_IMAGE_PATHS[0]],
     },
@@ -50,34 +50,35 @@ export default async function OpenHouseSignInPage({ params }: Props) {
             {listingAddress ? listingAddress : 'Open House'}
           </h1>
           <p className="text-gray-600 mt-1">
-            Schedule a private tour with Dr. Jan Duffy, or sign in with the agent at the open house.
+            Schedule a private tour with Dr. Jan Duffy—pick a time below.
           </p>
           <p className="text-sm text-gray-500 mt-2">
             Dr. Jan Duffy · Berkshire Hathaway HomeServices Nevada Properties
+          </p>
+          <p className="text-sm text-gray-600 mt-3">
+            <a href={`mailto:${GBP.email}`} className="text-blue-600 hover:underline font-medium">
+              {GBP.email}
+            </a>
+            {' · '}
+            <a href={`tel:${GBP.phoneE164}`} className="text-blue-600 hover:underline">
+              {GBP.phone}
+            </a>
           </p>
           <CalendlyPopupLink className="inline-block mt-4 bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-3 rounded-xl font-semibold transition-colors">
             Schedule a private showing
           </CalendlyPopupLink>
         </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm mb-10">
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
           <CalendlyInlineWidget
             minWidth={320}
             height={700}
             className="rounded-lg overflow-hidden w-full"
           />
         </div>
-
-        <section className="border-t border-gray-200 pt-10" aria-labelledby="signin-heading">
-          <h2 id="signin-heading" className="text-xl font-bold text-gray-900 mb-2 text-center">
-            Sign in at the open house
-          </h2>
-          <p className="text-gray-600 text-center text-sm mb-6">
-            Visiting today? Sign in below so we can stay in touch.
-          </p>
-          <div className="max-w-lg mx-auto">
-            <OpenHouseSignInForm listingId={listingId} listingAddress={listingAddress} />
-          </div>
-        </section>
+        <p className="text-center text-sm text-gray-500 mt-6">
+          Visiting an open house today? Ask the listing agent for the visitor log at the door, or book a follow-up
+          tour above.
+        </p>
       </main>
     </div>
   )

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -136,7 +136,7 @@ export default function PrivacyPolicyPage() {
               <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">8. Contact Us</h2>
               <p>If you have questions about this Privacy Policy, please contact us at:</p>
               <p>
-                <strong>Email:</strong> privacy@openhousemarketplace.com<br />
+                <strong>Email:</strong> {GBP.email}<br />
                 <strong>Phone:</strong> (702) 200-3422<br />
                 <strong>Address:</strong> {GBP.address.street}, {GBP.address.locality}, {GBP.address.region} {GBP.address.postalCode}
               </p>

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import { BASE_URL } from '@/lib/metadata-utils'
+import { GBP } from '@/config/gbp'
 
 import StructuredData from '@/components/StructuredData'
 import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
@@ -109,7 +110,7 @@ export default function TermsOfServicePage() {
                 If you have any questions about these Terms of Service, please contact us at:
               </p>
               <p>
-                <strong>Email:</strong> contact@openhousemarketplace.com<br />
+                <strong>Email:</strong> {GBP.email}<br />
                 <strong>Phone:</strong> (702) 200-3422
               </p>
             </section>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { Home, Phone, MapPin, Calendar } from 'lucide-react'
+import { Home, Phone, MapPin, Calendar, Mail } from 'lucide-react'
 import { useState } from 'react'
 import CalendlyPopupLink from '@/components/CalendlyPopupLink'
 import ExternalLink from '@/components/ExternalLink'
@@ -13,6 +13,8 @@ const BUSINESS = {
   name: GBP.name,
   phone: GBP.phone,
   phoneLink: `tel:${GBP.phoneE164}`,
+  email: GBP.email,
+  emailLink: `mailto:${GBP.email}`,
   address: `${GBP.address.street}, ${GBP.address.locality}, ${GBP.address.region} ${GBP.address.postalCode}`,
   directionsUrl: getGoogleMapsDirectionsUrlToOffice(),
   serviceArea: GBP_SERVICE_AREA.label,
@@ -40,6 +42,12 @@ export default function Footer() {
               <li className="flex items-center gap-2">
                 <Phone className="h-4 w-4 shrink-0 text-red-500" aria-hidden />
                 <a href={BUSINESS.phoneLink} className="min-h-[44px] inline-flex items-center hover:text-white">{BUSINESS.phone}</a>
+              </li>
+              <li className="flex items-center gap-2">
+                <Mail className="h-4 w-4 shrink-0 text-red-500" aria-hidden />
+                <a href={BUSINESS.emailLink} className="min-h-[44px] inline-flex items-center hover:text-white break-all">
+                  {BUSINESS.email}
+                </a>
               </li>
               <li className="flex items-start gap-2">
                 <MapPin className="h-4 w-4 shrink-0 text-red-500 mt-0.5" aria-hidden />

--- a/components/GoogleBusinessProfile.tsx
+++ b/components/GoogleBusinessProfile.tsx
@@ -26,7 +26,7 @@ const BUSINESS_INFO = {
   name: GBP.name,
   phone: GBP.phone,
   phoneLink: `tel:${GBP.phoneE164}`,
-  email: 'jan@openhousemarketplace.com',
+  email: GBP.email,
   address: {
     street: GBP.address.street,
     city: GBP.address.locality,

--- a/components/NeighborhoodPage.tsx
+++ b/components/NeighborhoodPage.tsx
@@ -176,7 +176,12 @@ const NeighborhoodPage: React.FC<NeighborhoodPageProps> = ({ neighborhood }) => 
                      </div>
                     <div className="flex items-center">
                       <Mail className="h-4 w-4 text-blue-600 mr-3" />
-                      <span className="text-gray-600">jan@summerlinexpert.com</span>
+                      <a
+                        href={`mailto:${GBP.email}`}
+                        className="text-gray-600 hover:text-blue-600 transition-colors break-all"
+                      >
+                        {GBP.email}
+                      </a>
                     </div>
                     <div className="flex items-center">
                       <Award className="h-4 w-4 text-blue-600 mr-3" />

--- a/components/RealScoutIntegration.tsx
+++ b/components/RealScoutIntegration.tsx
@@ -76,7 +76,9 @@ const RealScoutIntegration = () => {
            </div>
           <div className="flex items-center">
             <Mail className="h-4 w-4 mr-1" />
-            <span>jan@summerlinexpert.com</span>
+            <a href={`mailto:${GBP.email}`} className="hover:text-blue-600 transition-colors break-all">
+              {GBP.email}
+            </a>
           </div>
         </div>
       </div>

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -32,7 +32,7 @@ export default function StructuredData({ type, data = {} }: StructuredDataProps)
         url: `${baseUrl}/about`,
         image: `${baseUrl}/images/dr-jan-duffy.jpg`,
         telephone: GBP.phoneE164,
-        email: 'jan@openhousemarketplace.com',
+        email: GBP.email,
         address: {
           '@type': 'PostalAddress',
           streetAddress: GBP.address.street,
@@ -81,6 +81,7 @@ export default function StructuredData({ type, data = {} }: StructuredDataProps)
         contactPoint: {
           '@type': 'ContactPoint',
           telephone: GBP.phoneE164,
+          email: GBP.email,
           contactType: 'Real Estate Services',
           areaServed: 'US',
           availableLanguage: 'English'
@@ -158,7 +159,7 @@ export default function StructuredData({ type, data = {} }: StructuredDataProps)
         logo: `${baseUrl}/images/logo/logo.svg`,
         url: baseUrl,
         telephone: GBP.phoneE164,
-        email: 'jan@openhousemarketplace.com',
+        email: GBP.email,
         address: {
           '@type': 'PostalAddress',
           streetAddress: GBP.address.street,

--- a/components/SummerlinOpenHouseWebsite.tsx
+++ b/components/SummerlinOpenHouseWebsite.tsx
@@ -317,7 +317,12 @@ const SummerlinOpenHouseWebsite = () => {
           <p className="text-gray-300 mb-4 max-w-xl mx-auto">
             Your trusted Summerlin West real estate expert. Summerlin West & Las Vegas · Certified Luxury Home Specialist
           </p>
-          <p className="text-gray-400 text-sm mb-4">{GBP.address.street}, {GBP.address.locality}, {GBP.address.region} {GBP.address.postalCode}</p>
+          <p className="text-gray-400 text-sm mb-2">{GBP.address.street}, {GBP.address.locality}, {GBP.address.region} {GBP.address.postalCode}</p>
+          <p className="text-gray-400 text-sm mb-4">
+            <a href={`mailto:${GBP.email}`} className="hover:text-white transition-colors">
+              {GBP.email}
+            </a>
+          </p>
           <div className="flex flex-wrap justify-center gap-4">
             <a href={`tel:${GBP.phoneE164}`} className="inline-flex items-center justify-center min-h-[44px] gap-2 bg-blue-600 hover:bg-blue-700 px-5 py-2.5 rounded-lg font-medium">
               <Phone className="h-4 w-4" aria-hidden />

--- a/config/gbp.ts
+++ b/config/gbp.ts
@@ -7,6 +7,7 @@
  * - Name: Open House Market Place | Category: Real estate agent
  * - Phone: (702) 200-3422 | Chat/SMS: sms:+17022003422
  * - Website (GBP field): use **https://www.openhousemarketplace.com/** (canonical). If the profile still shows apex, update it in Google so it matches this site’s indexed URL.
+ * - Email: DrJanSells@OpenHouseMarketplace.com
  * - Address: 760 Windover Ct, Las Vegas, NV 89138
  * - Hours: daily 9:00 AM–5:00 PM. If Wednesday shows 5:00 AM in GBP, fix to 5:00 PM in Google Business Profile.
  * - Special: Apr 5, 2026 (Easter) — Closed
@@ -73,6 +74,8 @@ export const GBP = {
     postalCode: '89138',
     country: 'US',
   },
+  /** Public contact email (exact match to GBP / site contact) */
+  email: 'DrJanSells@OpenHouseMarketplace.com',
   /** Main phone (exact match to GBP) */
   phone: '(702) 200-3422',
   /** E.164 for tel: and schema */

--- a/config/indexing-pages.ts
+++ b/config/indexing-pages.ts
@@ -294,7 +294,7 @@ export const INDEXING_PAGE_CONTENT: Record<string, IndexingPageContent> = {
       },
       {
         question: 'How do I contact you about privacy?',
-        answer: `Email jan@openhousemarketplace.com or call ${PHONE}. Our office is at ${GBP.address.street}, ${GBP.address.locality}, ${GBP.address.region}.`,
+        answer: `Email ${GBP.email} or call ${PHONE}. Our office is at ${GBP.address.street}, ${GBP.address.locality}, ${GBP.address.region}.`,
       },
     ],
     relatedLinks: [

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -25,7 +25,7 @@ Internal reference for **implementation** on this repo: stack, boundaries, and w
 | Integration | Notes |
 |-------------|--------|
 | **RealScout** | Script once in layout pattern; widgets use `dangerouslySetInnerHTML` where applicable. **CSP:** `em.realscout.com` + `www.realscout.com` in `script-src` and `connect-src` — see [`lib/csp-header.mjs`](../lib/csp-header.mjs). |
-| **Calendly** | Popup / inline widgets; **primary** scheduling and lead capture UX (replaces on-site forms for normal operation). |
+| **Calendly** | Popup / inline widgets; **only** public scheduling UX—no contact or sign-in forms on the site. Public contact email: `GBP.email` in [`config/gbp.ts`](../config/gbp.ts). |
 | **Google Analytics** | gtag in [`app/layout.tsx`](../app/layout.tsx); `afterInteractive` or as tuned for perf. |
 | **Google Maps** | API key via env; Maps Platform embeds (My Maps, Commutes, Neighborhood Discovery) URLs in `lib/google-*.ts`. |
 | **Follow Up Boss** | **Optional** legacy server integration [`lib/followupboss-service.ts`](../lib/followupboss-service.ts). No key required in Vercel unless you explicitly wire CRM sync. |

--- a/docs/soul.md
+++ b/docs/soul.md
@@ -15,7 +15,7 @@ Internal reference for **content, UX copy, and AI-assisted writing** on [openhou
 | Name | **Dr. Jan Duffy** — never "Janet" or casual wrong variants in marketing copy. |
 | License | Nevada **S.0197614.LLC** — use where license disclosure is required. |
 | Brokerage | **Berkshire Hathaway HomeServices Nevada Properties** when citing affiliation. |
-| NAP | Match GBP exactly: phone **(702) 200-3422**, address **760 Windover Ct, Las Vegas, NV 89138**. Do not invent alternate numbers or addresses. |
+| NAP | Match GBP exactly: phone **(702) 200-3422**, email **DrJanSells@OpenHouseMarketplace.com**, address **760 Windover Ct, Las Vegas, NV 89138**. Do not invent alternate numbers, emails, or addresses. |
 | Website vs GBP | GBP may list apex `openhousemarketplace.com`; canonical site is **www** (redirect). |
 
 ## Voice & tone

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -97,7 +97,7 @@ export function buildSiteEntityGraph(baseUrl: string = getSiteUrl()) {
     },
     image: `${baseUrl}/images/dr-jan-duffy.jpg`,
     telephone: GBP.phoneE164,
-    email: 'jan@openhousemarketplace.com',
+    email: GBP.email,
     address: {
       '@type': 'PostalAddress',
       streetAddress: GBP.address.street,
@@ -116,6 +116,7 @@ export function buildSiteEntityGraph(baseUrl: string = getSiteUrl()) {
     contactPoint: {
       '@type': 'ContactPoint',
       telephone: GBP.phoneE164,
+      email: GBP.email,
       contactType: 'customer service',
       areaServed: 'US',
       availableLanguage: 'English',
@@ -151,7 +152,7 @@ export function buildSiteEntityGraph(baseUrl: string = getSiteUrl()) {
     url: `${baseUrl}/about`,
     image: `${baseUrl}/images/dr-jan-duffy.jpg`,
     telephone: GBP.phoneE164,
-    email: 'jan@openhousemarketplace.com',
+    email: GBP.email,
     description:
       'Licensed Nevada real estate professional serving Summerlin West and the Las Vegas Valley. Expert in open houses, luxury homes, and new construction.',
     worksFor: { '@id': organizationId },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Standardizes public contact on **DrJanSells@OpenHouseMarketplace.com** and removes on-site lead/contact forms in favor of **Calendly only**.

## Email (single source: `config/gbp.ts`)

- `GBP.email` = `DrJanSells@OpenHouseMarketplace.com`
- Visible on: footer, contact GBP card, homepage strip, open-house QR pages, neighborhood/RealScout sidebars, terms, privacy, disclaimer, FAQ/indexing copy, JSON-LD

## No public forms

- **Removed** open-house sign-in form from `/open-house-signin/[listingId]` — Calendly inline + popup only
- **POST disabled (410)** on `/api/contact`, `/api/leads`, `/api/open-house-signin` with `scheduleUrl` + `email` in JSON
- Admin open-house sign-in **GET** unchanged for internal use
- Contact, open-house-guide, and other marketing pages already used Calendly (unchanged)

## Docs

- `docs/soul.md`, `docs/skill.md`, `CHANGELOG.md`, `.env.example` updated

## Verify after deploy

1. Footer and `/contact` show **DrJanSells@OpenHouseMarketplace.com** only (no other `@openhousemarketplace.com` addresses in UI)
2. Scan a yard-sign QR → Calendly widget, no HTML form
3. `POST /api/contact` returns 410 with Calendly URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9cbf83b-91ba-4ffd-ad1d-0f26a43dc1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9cbf83b-91ba-4ffd-ad1d-0f26a43dc1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

