### PR TITLE
Sitewide SEO/GEO/AEO enhancements and brand color palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Site update (June 2026)
 
+* **SEO / GEO / AEO sitewide:** `PageIndexingEnhancement` on all 41 marketing sitemap URLs; expanded `config/indexing-pages.ts` (home, open houses, neighborhoods hub, amenity map, store locations, consultation, sitemap, disclaimer, four luxury villages).
+* **Brand palette (sitewide):** `config/brand.ts`, `lib/brand-classes.ts`, Tailwind `brand-*` tokens; 70+ app pages and shared components migrated from legacy blue/red/green; RealScout widget CSS, Calendly badge, map markers, and `themeColor` use palette; header, footer, homepage, and enhancement sections updated.
 * **Vercel deploy audit:** Document repo transfer (LetMeHelpYouREALTY vs DrJanDuffy), correct `prj_UH4vlCl7EkB4ipEIvu7kflQN3p2E`, stale production SHA; GitHub Actions guard for drjanduffy project ID.
 * **GSC canonical:** `/index`, `/index/`, `/index.html` → **301** to `/` (Vercel edge, `next.config`, middleware, `app/index/route.ts`) — fixes “Duplicate without user-selected canonical”.
 * **GSC indexing:** `PageIndexingEnhancement` + `config/indexing-pages.ts` (FAQs, speakable summaries, internal links) on 28 discovered URLs; privacy/terms set to `index`; sitemap `lastModified`; home-buying HowTo.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -56,7 +56,7 @@ export default function AboutPage() {
       {/* FAQPage JSON-LD is emitted by FAQSection below (single graph per URL). */}
       <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative h-[50vh] min-h-[400px] bg-gradient-to-r from-blue-600 to-red-600 rounded-b-3xl overflow-hidden">
+      <section className="relative h-[50vh] min-h-[400px] bg-gradient-to-r from-brand-teal to-brand-plum rounded-b-3xl overflow-hidden">
         <div className="absolute inset-0 bg-black bg-opacity-40" />
         <div className="absolute inset-0 flex items-center justify-center text-center">
           <div className="max-w-4xl mx-auto px-4">
@@ -98,7 +98,7 @@ export default function AboutPage() {
           <p className="text-gray-700 leading-relaxed mb-4">
             Specializing in luxury homes, new construction properties, and investment real estate, Dr. Duffy provides 
             personalized service tailored to each client&apos;s unique needs. She also helps buyers find and tour Summerlin 
-            open houses—see our <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">open houses</Link> page for this weekend&apos;s home tours. Her comprehensive knowledge of Summerlin 
+            open houses—see our <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">open houses</Link> page for this weekend&apos;s home tours. Her comprehensive knowledge of Summerlin 
             neighborhoods, from The Ridges to Summerlin Centre, ensures that clients receive expert guidance throughout 
             their real estate journey. Whether you&apos;re a first-time homebuyer, luxury property investor, or looking to 
             sell your home, Dr. Duffy&apos;s market expertise and proven strategies ensure successful transactions.
@@ -114,22 +114,22 @@ export default function AboutPage() {
         {/* Stats Grid */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-12">
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
-            <Home className="h-10 w-10 text-blue-600 mx-auto mb-4" />
+            <Home className="h-10 w-10 text-brand-teal mx-auto mb-4" />
             <div className="text-3xl font-bold text-gray-900 mb-2">500+</div>
             <div className="text-gray-600">Homes Sold</div>
           </div>
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
-            <Award className="h-10 w-10 text-blue-600 mx-auto mb-4" />
+            <Award className="h-10 w-10 text-brand-teal mx-auto mb-4" />
             <div className="text-3xl font-bold text-gray-900 mb-2">30+</div>
             <div className="text-gray-600">Years Experience</div>
           </div>
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
-            <Users className="h-10 w-10 text-blue-600 mx-auto mb-4" />
+            <Users className="h-10 w-10 text-brand-teal mx-auto mb-4" />
             <div className="text-3xl font-bold text-gray-900 mb-2">1000+</div>
             <div className="text-gray-600">Happy Clients</div>
           </div>
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
-            <TrendingUp className="h-10 w-10 text-blue-600 mx-auto mb-4" />
+            <TrendingUp className="h-10 w-10 text-brand-teal mx-auto mb-4" />
             <div className="text-3xl font-bold text-gray-900 mb-2">$250M+</div>
             <div className="text-gray-600">In Sales Volume</div>
           </div>
@@ -212,7 +212,7 @@ export default function AboutPage() {
           <h2 className="text-3xl font-bold text-gray-900 mb-6">Core Values & Professional Commitment</h2>
           <div className="space-y-6">
             <div className="flex items-start">
-              <Heart className="h-6 w-6 text-red-600 mt-1 mr-4 flex-shrink-0" />
+              <Heart className="h-6 w-6 text-brand-teal mt-1 mr-4 flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-2">Client-First Approach</h3>
                 <p className="text-gray-700 leading-relaxed mb-2">
@@ -229,7 +229,7 @@ export default function AboutPage() {
               </div>
             </div>
             <div className="flex items-start">
-              <Award className="h-6 w-6 text-blue-600 mt-1 mr-4 flex-shrink-0" />
+              <Award className="h-6 w-6 text-brand-teal mt-1 mr-4 flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-2">Expertise & Market Knowledge</h3>
                 <p className="text-gray-700 leading-relaxed mb-2">
@@ -245,7 +245,7 @@ export default function AboutPage() {
               </div>
             </div>
             <div className="flex items-start">
-              <TrendingUp className="h-6 w-6 text-green-600 mt-1 mr-4 flex-shrink-0" />
+              <TrendingUp className="h-6 w-6 text-brand-teal mt-1 mr-4 flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-2">Results-Driven Excellence</h3>
                 <p className="text-gray-700 leading-relaxed mb-2">
@@ -262,7 +262,7 @@ export default function AboutPage() {
               </div>
             </div>
             <div className="flex items-start">
-              <Users className="h-6 w-6 text-purple-600 mt-1 mr-4 flex-shrink-0" />
+              <Users className="h-6 w-6 text-brand-teal mt-1 mr-4 flex-shrink-0" />
               <div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-2">Professional Network & Resources</h3>
                 <p className="text-gray-700 leading-relaxed mb-2">
@@ -343,7 +343,7 @@ export default function AboutPage() {
         </div>
 
         {/* CTA */}
-        <div className="bg-blue-600 rounded-lg shadow-md p-8 text-center text-white">
+        <div className="bg-brand-teal rounded-lg shadow-md p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Ready to Work with Las Vegas&apos; Top Real Estate Agent?</h2>
           <p className="text-xl mb-6">Let&apos;s work together to achieve your real estate goals in Summerlin West</p>
           <p className="text-lg mb-6 opacity-90">
@@ -354,25 +354,25 @@ export default function AboutPage() {
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/contact"
-              className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
+              className="inline-block bg-white text-brand-teal px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
             >
               Contact Dr. Jan Duffy Today
             </Link>
             <Link
               href="/open-houses"
-              className="inline-block bg-blue-500 hover:bg-blue-400 text-white px-8 py-3 rounded-lg font-bold text-lg border-2 border-white/50 transition-colors"
+              className="inline-block bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg border-2 border-white/50 transition-colors"
             >
               View Summerlin Open Houses
             </Link>
-            <CalendlyPopupLink className="inline-block bg-[#0069ff] hover:bg-[#0052cc] text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
+            <CalendlyPopupLink className="inline-block bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
               Schedule a private showing
             </CalendlyPopupLink>
           </div>
         </div>
 
-        <div className="bg-amber-50 border border-amber-100 rounded-lg p-6 mb-8 text-center">
+        <div className="bg-brand-mint/40 border border-brand-mint rounded-lg p-6 mb-8 text-center">
           <p className="text-gray-800 font-medium mb-2">Love your experience with Dr. Jan Duffy?</p>
-          <Link href="/review-us" className="text-blue-600 hover:underline font-semibold">
+          <Link href="/review-us" className="text-brand-teal hover:underline font-semibold">
             Leave a review on Google
           </Link>
           <span className="text-gray-600"> — reviews help other customers find us.</span>

--- a/app/admin/open-house-signin/page.tsx
+++ b/app/admin/open-house-signin/page.tsx
@@ -134,11 +134,11 @@ export default function AdminOpenHouseSignInPage() {
             required
             disabled={loginSubmitting}
           />
-          {loginError && <p className="text-red-600 text-sm mb-2">{loginError}</p>}
+          {loginError && <p className="text-brand-teal text-sm mb-2">{loginError}</p>}
           <button
             type="submit"
             disabled={loginSubmitting}
-            className="w-full rounded-lg bg-blue-600 text-white font-semibold py-2 hover:bg-blue-700 disabled:opacity-50"
+            className="w-full rounded-lg bg-brand-teal text-white font-semibold py-2 hover:bg-brand-plum disabled:opacity-50"
           >
             {loginSubmitting ? 'Logging in…' : 'Log in'}
           </button>
@@ -183,7 +183,7 @@ export default function AdminOpenHouseSignInPage() {
             <button
               type="submit"
               disabled={saveSubmitting}
-              className="rounded-lg bg-blue-600 text-white font-semibold px-4 py-2 hover:bg-blue-700 disabled:opacity-50"
+              className="rounded-lg bg-brand-teal text-white font-semibold px-4 py-2 hover:bg-brand-plum disabled:opacity-50"
             >
               {saveSubmitting ? 'Saving…' : 'Save & generate QR'}
             </button>
@@ -200,7 +200,7 @@ export default function AdminOpenHouseSignInPage() {
                 <a
                   href={qrUrl}
                   download={`open-house-signin-${listingId}.png`}
-                  className="text-blue-600 font-medium hover:underline"
+                  className="text-brand-teal font-medium hover:underline"
                 >
                   Download PNG
                 </a>
@@ -229,7 +229,7 @@ export default function AdminOpenHouseSignInPage() {
             </button>
           </form>
           {submissionsError && (
-            <p className="text-red-600 text-sm mb-2">{submissionsError}</p>
+            <p className="text-brand-teal text-sm mb-2">{submissionsError}</p>
           )}
           {submissions.length === 0 && !submissionsLoading && (
             <p className="text-gray-500 text-sm">Enter a listing ID and click Load.</p>

--- a/app/amenity-map/page.tsx
+++ b/app/amenity-map/page.tsx
@@ -56,7 +56,7 @@ export default function AmenityMapPage() {
           <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
             <ol className="flex flex-wrap gap-x-2 gap-y-1">
               <li>
-                <Link href="/" className="hover:text-blue-600 transition-colors">
+                <Link href="/" className="hover:text-brand-plum transition-colors">
                   Home
                 </Link>
               </li>
@@ -90,7 +90,7 @@ export default function AmenityMapPage() {
             <AmenityMap />
           </section>
 
-          <div className="mt-8 p-4 bg-blue-50 rounded-lg border border-blue-100">
+          <div className="mt-8 p-4 bg-brand-mint/40 rounded-lg border border-brand-mint">
             <p className="text-sm text-gray-700">
               <strong>Tip:</strong> This map shows places near Summerlin. Use the filters above to
               switch between restaurants, parks, cafes, grocery, gyms, and more. Click a marker for
@@ -104,27 +104,27 @@ export default function AmenityMapPage() {
               Summerlin West, Las Vegas, NV 89135
             </p>
             <p className="text-sm mb-3">
-              <a href="tel:+17022003422" className="text-blue-600 font-medium hover:underline">
+              <a href="tel:+17022003422" className="text-brand-teal font-medium hover:underline">
                 (702) 200-3422
               </a>
             </p>
             <div className="flex flex-wrap gap-3">
               <a
                 href="tel:+17022003422"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-teal hover:underline"
               >
                 Call
               </a>
               <ExternalLink
                 href="https://www.google.com/maps/dir/?api=1&destination=Summerlin+West,+Las+Vegas,+NV+89135"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-teal hover:underline"
                 showIcon={false}
               >
                 Directions
               </ExternalLink>
               <ExternalLink
                 href="https://www.google.com/maps/place/?q=Dr+Jan+Duffy+Real+Estate+Summerlin+West+Las+Vegas+NV&action=reviews"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-teal hover:underline"
                 showIcon={false}
               >
                 View Google Reviews

--- a/app/amenity-map/page.tsx
+++ b/app/amenity-map/page.tsx
@@ -6,6 +6,7 @@ import AmenityMap from '@/components/AmenityMap'
 import ExternalLink from '@/components/ExternalLink'
 import GoogleMyMapsSection from '@/components/GoogleMyMapsSection'
 import StructuredData from '@/components/StructuredData'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Amenity Map | Nearby Restaurants, Parks, Parking & More | Summerlin',
@@ -132,6 +133,7 @@ export default function AmenityMapPage() {
           </div>
         </div>
       </main>
+      <PageIndexingEnhancement path="/amenity-map" />
     </>
   )
 }

--- a/app/book-tour/page.tsx
+++ b/app/book-tour/page.tsx
@@ -51,7 +51,7 @@ export default function BookTourPage() {
           <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
             <ol className="flex flex-wrap gap-x-2 gap-y-1">
               <li>
-                <Link href="/" className="hover:text-blue-600 transition-colors">
+                <Link href="/" className="hover:text-brand-plum transition-colors">
                   Home
                 </Link>
               </li>
@@ -78,9 +78,9 @@ export default function BookTourPage() {
             </p>
             <p>
               Before your tour, share your budget, preferred zip codes (89135, 89138, 89144), and must-haves. You can also browse{' '}
-              <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link>
+              <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link>
               {' '}or{' '}
-              <Link href="/tour/mls" className="text-blue-600 font-semibold hover:underline">MLS listings</Link>
+              <Link href="/tour/mls" className="text-brand-teal font-semibold hover:underline">MLS listings</Link>
               {' '}to build a shortlist.
             </p>
           </section>
@@ -94,11 +94,11 @@ export default function BookTourPage() {
           </section>
 
           <p className="mt-6 text-center text-sm text-gray-500">
-            Prefer to call? <a href="tel:+17022003422" className="text-blue-600 hover:underline">(702) 200-3422</a>
+            Prefer to call? <a href="tel:+17022003422" className="text-brand-teal hover:underline">(702) 200-3422</a>
             {' · '}
-            <Link href="/schedule-consultation" className="text-blue-600 hover:underline">Schedule a free consultation</Link>
+            <Link href="/schedule-consultation" className="text-brand-teal hover:underline">Schedule a free consultation</Link>
             {' · '}
-            <Link href="/review-us" className="text-blue-600 hover:underline">Review us on Google</Link>
+            <Link href="/review-us" className="text-brand-teal hover:underline">Review us on Google</Link>
           </p>
         </div>
       </main>

--- a/app/buyers/page.tsx
+++ b/app/buyers/page.tsx
@@ -58,11 +58,11 @@ export default function BuyersPage() {
               description={
                 <>
                   Use the map to browse areas and context across Summerlin. For commute times, see{' '}
-                  <Link href="/directions" className="text-blue-600 font-medium hover:underline">
+                  <Link href="/directions" className="text-brand-teal font-medium hover:underline">
                     directions & commute explorer
                   </Link>
                   ; for community guides, see{' '}
-                  <Link href="/neighborhoods" className="text-blue-600 font-medium hover:underline">
+                  <Link href="/neighborhoods" className="text-brand-teal font-medium hover:underline">
                     all neighborhoods
                   </Link>
                   .
@@ -80,7 +80,7 @@ export default function BuyersPage() {
             </p>
             <Link
               href="/tour/mls"
-              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors"
+              className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors"
             >
               <Search className="h-5 w-5" aria-hidden />
               Search Listings

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -70,7 +70,7 @@ export default function ContactPage() {
           <p className="text-xl text-gray-600 mb-6">
             Your trusted real estate agent serving Summerlin West and all of Las Vegas
           </p>
-          <CalendlyPopupLink className="inline-block bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-3 rounded-xl font-semibold transition-colors">
+          <CalendlyPopupLink className="inline-block bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-xl font-semibold transition-colors">
             Schedule a private showing
           </CalendlyPopupLink>
         </div>
@@ -92,7 +92,7 @@ export default function ContactPage() {
                 Looking to buy or sell a home in Summerlin West? Dr. Jan Duffy is your trusted Las Vegas real estate 
                 agent with over 30 years of experience helping clients navigate the Summerlin real estate market. 
                 Whether you&apos;re searching for luxury homes in The Ridges, family-friendly properties in Summerlin Centre, 
-                <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline mx-1">Summerlin open houses</Link> this weekend, 
+                <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline mx-1">Summerlin open houses</Link> this weekend, 
                 or investment opportunities throughout Las Vegas, Dr. Duffy provides personalized service tailored to 
                 your unique real estate goals.
               </p>
@@ -100,7 +100,7 @@ export default function ContactPage() {
                 As a leading Summerlin West real estate agent, Dr. Duffy specializes in luxury homes, new construction 
                 properties, and investment real estate. Her deep knowledge of the Las Vegas market, combined with 
                 cutting-edge technology and proven marketing strategies, ensures successful transactions for both buyers 
-                and sellers. <CalendlyPopupLink className="text-blue-600 font-semibold hover:underline">Schedule a free consultation</CalendlyPopupLink> or 
+                and sellers. <CalendlyPopupLink className="text-brand-teal font-semibold hover:underline">Schedule a free consultation</CalendlyPopupLink> or 
                 contact us today to discover why thousands of clients trust Dr. Jan Duffy with their real estate needs.
               </p>
             </div>
@@ -147,7 +147,7 @@ export default function ContactPage() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-gray-900 mb-1">
-                  <Link href="/open-houses" className="text-blue-600 hover:underline">Open House Tours</Link>
+                  <Link href="/open-houses" className="text-brand-teal hover:underline">Open House Tours</Link>
                 </h3>
                 <p className="text-gray-600 text-sm">Find and tour Summerlin open houses this weekend</p>
               </div>
@@ -155,9 +155,9 @@ export default function ContactPage() {
           </div>
         </div>
 
-        <div className="bg-blue-50 border border-blue-100 rounded-lg p-6 mb-8 text-center">
+        <div className="bg-brand-mint/40 border border-brand-mint rounded-lg p-6 mb-8 text-center">
           <p className="text-gray-800 font-medium mb-2">Enjoyed working with us?</p>
-          <Link href="/review-us" className="text-blue-600 hover:underline font-semibold">
+          <Link href="/review-us" className="text-brand-teal hover:underline font-semibold">
             Leave a review on Google
           </Link>
           <span className="text-gray-600"> — it helps other customers find us.</span>
@@ -282,7 +282,7 @@ export default function ContactPage() {
           />
         </div>
 
-        <div className="bg-blue-50 rounded-lg p-6 mt-8">
+        <div className="bg-brand-mint/40 rounded-lg p-6 mt-8">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">Ready to Start Your Real Estate Journey?</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Don't wait to achieve your real estate goals in Summerlin West. Whether you're looking to buy your 

--- a/app/directions/page.tsx
+++ b/app/directions/page.tsx
@@ -55,7 +55,7 @@ export default function DirectionsPage() {
           <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
             <ol className="flex flex-wrap gap-x-2 gap-y-1">
               <li>
-                <Link href="/" className="hover:text-blue-600 transition-colors">
+                <Link href="/" className="hover:text-brand-plum transition-colors">
                   Home
                 </Link>
               </li>
@@ -97,7 +97,7 @@ export default function DirectionsPage() {
                 No destinations configured. Add store locations in{' '}
                 <code className="text-sm bg-gray-200 px-1 rounded">data/storeLocations.ts</code> to enable directions.
               </p>
-              <Link href="/store-locations" className="mt-4 inline-block text-blue-600 font-medium hover:underline">
+              <Link href="/store-locations" className="mt-4 inline-block text-brand-teal font-medium hover:underline">
                 View store locations →
               </Link>
             </div>
@@ -127,9 +127,9 @@ export default function DirectionsPage() {
             </section>
           )}
 
-          <div className="mt-8 p-4 bg-blue-50 rounded-lg border border-blue-100">
+          <div className="mt-8 p-4 bg-brand-mint/40 rounded-lg border border-brand-mint">
             <p className="text-sm text-gray-700">
-              <strong>Tip:</strong> Click &quot;My location&quot; to use your current position as the starting point. You can also <Link href="/store-locations" className="text-blue-600 hover:underline">view all our store locations</Link> on a map.
+              <strong>Tip:</strong> Click &quot;My location&quot; to use your current position as the starting point. You can also <Link href="/store-locations" className="text-brand-teal hover:underline">view all our store locations</Link> on a map.
             </p>
           </div>
         </div>

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next'
 import { BASE_URL, DEFAULT_OG_IMAGE_PATHS } from '@/lib/metadata-utils'
 
 import StructuredData from '@/components/StructuredData'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
+import { GBP } from '@/config/gbp'
 
 export const revalidate = 2592000 // ISR: revalidate every 30 days (legal)
 
@@ -122,7 +124,7 @@ export default function DisclaimerPage() {
               <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">9. Contact Information</h2>
               <p>For questions about this disclaimer, please contact:</p>
               <p>
-                <strong>Email:</strong> contact@openhousemarketplace.com<br />
+                <strong>Email:</strong> {GBP.email}<br />
                 <strong>Phone:</strong> (702) 200-3422
               </p>
             </section>
@@ -130,6 +132,7 @@ export default function DisclaimerPage() {
         </div>
       </div>
     </div>
+    <PageIndexingEnhancement path="/disclaimer" />
     </>
   )
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -18,7 +18,7 @@ export default function Error({
   return (
     <div className="min-h-[70vh] flex flex-col items-center justify-center px-4 py-16">
       <div className="max-w-md w-full text-center">
-        <AlertCircle className="h-16 w-16 text-red-500 mx-auto mb-4" aria-hidden />
+        <AlertCircle className="h-16 w-16 text-brand-teal mx-auto mb-4" aria-hidden />
         <h1 className="text-2xl font-bold text-gray-900 mb-2">Something went wrong</h1>
         <p className="text-gray-600 mb-8">
           We couldn&apos;t load this page. Please try again or return home.
@@ -27,7 +27,7 @@ export default function Error({
           <button
             type="button"
             onClick={reset}
-            className="inline-flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-xl font-semibold transition-colors"
+            className="inline-flex items-center justify-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-xl font-semibold transition-colors"
           >
             <RefreshCw className="h-5 w-5" aria-hidden />
             Try again

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,7 +74,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  themeColor: '#2563eb',
+  themeColor: '#4a3861',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/luxury-homes/page.tsx
+++ b/app/luxury-homes/page.tsx
@@ -117,7 +117,7 @@ export default function LuxuryHomesPage() {
               enjoy the benefits of master-planned community living alongside exclusive amenities and services.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including luxury homes in The Ridges and Red Rock Country Club.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including luxury homes in The Ridges and Red Rock Country Club.
             </p>
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Luxury Real Estate Market in Summerlin</h3>
             <p className="text-gray-700 leading-relaxed mb-4">

--- a/app/market-report/page.tsx
+++ b/app/market-report/page.tsx
@@ -44,7 +44,7 @@ export default function MarketReportPage() {
       />
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-blue-600 to-red-600">
+      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-brand-teal to-brand-plum">
         <div className="absolute inset-0 bg-black bg-opacity-40" />
         <div className="absolute inset-0 flex items-center justify-center text-center">
           <div className="max-w-4xl mx-auto px-4">
@@ -66,49 +66,49 @@ export default function MarketReportPage() {
           <p className="text-gray-600 leading-relaxed mb-6">
             The Summerlin West real estate market continues to show strength and resilience. 
             As of the latest reporting period, we&apos;re seeing steady appreciation in home values 
-            with strong buyer demand across all price points. See our <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> page for this weekend&apos;s home tours.
+            with strong buyer demand across all price points. See our <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> page for this weekend&apos;s home tours.
           </p>
 
           {/* Key Metrics Grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-            <div className="bg-blue-50 rounded-lg p-6">
+            <div className="bg-brand-mint/40 rounded-lg p-6">
               <div className="flex items-center justify-between mb-2">
-                <DollarSign className="h-6 w-6 text-blue-600" />
-                <TrendingUp className="h-5 w-5 text-green-600" />
+                <DollarSign className="h-6 w-6 text-brand-teal" />
+                <TrendingUp className="h-5 w-5 text-brand-teal" />
               </div>
               <div className="text-2xl font-bold text-gray-900">$850,000</div>
               <div className="text-sm text-gray-600">Median Home Price</div>
-              <div className="text-sm text-green-600 mt-1">+2.4% from last month</div>
+              <div className="text-sm text-brand-teal mt-1">+2.4% from last month</div>
             </div>
 
-            <div className="bg-purple-50 rounded-lg p-6">
+            <div className="bg-brand-mint/40 rounded-lg p-6">
               <div className="flex items-center justify-between mb-2">
-                <Home className="h-6 w-6 text-purple-600" />
-                <TrendingDown className="h-5 w-5 text-orange-600" />
+                <Home className="h-6 w-6 text-brand-teal" />
+                <TrendingDown className="h-5 w-5 text-brand-stone" />
               </div>
               <div className="text-2xl font-bold text-gray-900">142</div>
               <div className="text-sm text-gray-600">Active Listings</div>
-              <div className="text-sm text-orange-600 mt-1">-5.3% from last month</div>
+              <div className="text-sm text-brand-stone mt-1">-5.3% from last month</div>
             </div>
 
-            <div className="bg-green-50 rounded-lg p-6">
+            <div className="bg-brand-mint/40 rounded-lg p-6">
               <div className="flex items-center justify-between mb-2">
-                <Clock className="h-6 w-6 text-green-600" />
-                <TrendingUp className="h-5 w-5 text-green-600" />
+                <Clock className="h-6 w-6 text-brand-teal" />
+                <TrendingUp className="h-5 w-5 text-brand-teal" />
               </div>
               <div className="text-2xl font-bold text-gray-900">38 days</div>
               <div className="text-sm text-gray-600">Avg Days on Market</div>
-              <div className="text-sm text-green-600 mt-1">-3 days from last month</div>
+              <div className="text-sm text-brand-teal mt-1">-3 days from last month</div>
             </div>
 
-            <div className="bg-orange-50 rounded-lg p-6">
+            <div className="bg-brand-surface rounded-lg p-6">
               <div className="flex items-center justify-between mb-2">
-                <TrendingUp className="h-6 w-6 text-orange-600" />
-                <TrendingUp className="h-5 w-5 text-green-600" />
+                <TrendingUp className="h-6 w-6 text-brand-stone" />
+                <TrendingUp className="h-5 w-5 text-brand-teal" />
               </div>
               <div className="text-2xl font-bold text-gray-900">$325/sqft</div>
               <div className="text-sm text-gray-600">Price per Sq.Ft</div>
-              <div className="text-sm text-green-600 mt-1">+1.8% from last month</div>
+              <div className="text-sm text-brand-teal mt-1">+1.8% from last month</div>
             </div>
           </div>
         </div>
@@ -240,7 +240,7 @@ export default function MarketReportPage() {
               <tbody>
                 <tr className="border-b">
                   <td className="py-3 px-4">
-                    <Link href="/neighborhoods/the-ridges" className="text-blue-600 hover:text-blue-800">
+                    <Link href="/neighborhoods/the-ridges" className="text-brand-teal hover:text-brand-plum">
                       The Ridges
                     </Link>
                   </td>
@@ -250,7 +250,7 @@ export default function MarketReportPage() {
                 </tr>
                 <tr className="border-b">
                   <td className="py-3 px-4">
-                    <Link href="/neighborhoods/red-rock-country-club" className="text-blue-600 hover:text-blue-800">
+                    <Link href="/neighborhoods/red-rock-country-club" className="text-brand-teal hover:text-brand-plum">
                       Red Rock Country Club
                     </Link>
                   </td>
@@ -260,7 +260,7 @@ export default function MarketReportPage() {
                 </tr>
                 <tr className="border-b">
                   <td className="py-3 px-4">
-                    <Link href="/neighborhoods/summerlin-centre" className="text-blue-600 hover:text-blue-800">
+                    <Link href="/neighborhoods/summerlin-centre" className="text-brand-teal hover:text-brand-plum">
                       Summerlin Centre
                     </Link>
                   </td>
@@ -270,7 +270,7 @@ export default function MarketReportPage() {
                 </tr>
                 <tr>
                   <td className="py-3 px-4">
-                    <Link href="/neighborhoods/sun-city-summerlin" className="text-blue-600 hover:text-blue-800">
+                    <Link href="/neighborhoods/sun-city-summerlin" className="text-brand-teal hover:text-brand-plum">
                       Sun City Summerlin
                     </Link>
                   </td>
@@ -284,17 +284,17 @@ export default function MarketReportPage() {
         </div>
 
         {/* CTA */}
-        <div className="bg-blue-600 rounded-lg shadow-md p-8 text-center text-white">
+        <div className="bg-brand-teal rounded-lg shadow-md p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Get Your Personalized Market Analysis</h2>
           <p className="text-xl mb-6">Want to know what your home is worth? Contact us for a free valuation.</p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/contact"
-              className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
+              className="inline-block bg-white text-brand-teal px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
             >
               Request Free Market Analysis
             </Link>
-            <CalendlyPopupLink className="inline-flex items-center gap-2 bg-[#0069ff] hover:bg-[#0052cc] text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
+            <CalendlyPopupLink className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
               <Calendar className="h-5 w-5" aria-hidden />
               Schedule a private showing
             </CalendlyPopupLink>

--- a/app/neighborhoods/mesa-ridge/page.tsx
+++ b/app/neighborhoods/mesa-ridge/page.tsx
@@ -104,7 +104,7 @@ export default function MesaRidgePage() {
               play without leaving home.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Mesa Ridge.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Mesa Ridge.
             </p>
             <RelatedNeighborhoods currentSlug="mesa-ridge" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Real Estate Opportunities in Mesa Ridge</h3>

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -74,7 +74,7 @@ export default function NeighborhoodsIndexPage() {
         }}
       />
       <div className="min-h-screen bg-gray-50">
-        <section className="relative bg-gradient-to-r from-blue-600 to-slate-700 text-white py-16 md:py-20 rounded-b-3xl">
+        <section className="relative bg-gradient-to-r from-brand-teal to-brand-plum text-white py-16 md:py-20 rounded-b-3xl">
           <div className="max-w-4xl mx-auto px-4 text-center">
             <h1 className="text-4xl md:text-5xl font-bold mb-4">
               Summerlin Neighborhoods
@@ -87,7 +87,7 @@ export default function NeighborhoodsIndexPage() {
 
         <div className="max-w-6xl mx-auto px-4 py-12">
           {/* Office / Search Listings first */}
-          <div className="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-6">
+          <div className="mb-10 rounded-lg border border-brand-mint bg-brand-mint/40 p-6">
             <h2 className="text-xl font-semibold text-gray-900 mb-2">Office</h2>
             <p className="text-gray-700 mb-4">
               Search all Summerlin listings with Dr. Jan Duffy&apos;s home search. Get alerts for new listings, price drops, and open houses.
@@ -95,7 +95,7 @@ export default function NeighborhoodsIndexPage() {
             <div className="flex flex-wrap gap-3">
               <ExternalLink
                 href="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
-                className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
+                className="inline-block bg-brand-teal text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-plum transition-colors"
                 showIcon={false}
               >
                 Search Listings
@@ -127,7 +127,7 @@ export default function NeighborhoodsIndexPage() {
               >
                 <h3 className="text-xl font-semibold text-gray-900 mb-2">{n.name}</h3>
                 <p className="text-gray-600">{n.shortDescription}</p>
-                <span className="inline-block mt-3 text-blue-600 font-medium">
+                <span className="inline-block mt-3 text-brand-teal font-medium">
                   View homes in {n.name} →
                 </span>
               </Link>
@@ -141,12 +141,12 @@ export default function NeighborhoodsIndexPage() {
             </p>
             <Link
               href="/contact"
-              className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
+              className="inline-block bg-brand-teal text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-plum transition-colors"
             >
               Contact Dr. Jan Duffy
             </Link>
             <p className="text-sm text-gray-600 mt-4">
-              See <Link href="/sitemap" className="text-blue-600 hover:text-blue-800 font-medium">sitemap</Link> for all pages.
+              See <Link href="/sitemap" className="text-brand-teal hover:text-brand-plum font-medium">sitemap</Link> for all pages.
             </p>
           </div>
 

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -7,6 +7,7 @@ import ExternalLink from '@/components/ExternalLink'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
 import GoogleMapsNeighborhoodDiscoverySection from '@/components/GoogleMapsNeighborhoodDiscoverySection'
 import { CALENDLY_OPEN_HOUSE_TOUR_URL } from '@/lib/calendly'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const revalidate = 86400 // ISR: revalidate daily
 
@@ -168,6 +169,7 @@ export default function NeighborhoodsIndexPage() {
           </section>
         </div>
       </div>
+      <PageIndexingEnhancement path="/neighborhoods" />
     </>
   )
 }

--- a/app/neighborhoods/red-rock-country-club/page.tsx
+++ b/app/neighborhoods/red-rock-country-club/page.tsx
@@ -106,7 +106,7 @@ export default function RedRockCountryClubPage() {
               Club one of the most desirable communities for luxury real estate in Summerlin.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Red Rock Country Club.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Red Rock Country Club.
             </p>
             <RelatedNeighborhoods currentSlug="red-rock-country-club" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Luxury Real Estate Market in Red Rock Country Club</h3>

--- a/app/neighborhoods/red-rock-country-club/page.tsx
+++ b/app/neighborhoods/red-rock-country-club/page.tsx
@@ -4,6 +4,7 @@ import { BASE_URL } from '@/lib/metadata-utils'
 import Link from 'next/link'
 import HyperLocalNeighborhoodPage from '@/components/HyperLocalNeighborhoodPage'
 import RelatedNeighborhoods from '@/components/RelatedNeighborhoods'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Red Rock Country Club | Luxury Golf Course Homes for Sale',
@@ -151,6 +152,7 @@ export default function RedRockCountryClubPage() {
         imageUrl="/images/red-rock-cc-hero.jpg"
         realscoutUrl="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
       />
+      <PageIndexingEnhancement path="/neighborhoods/red-rock-country-club" />
     </div>
     </>
   )

--- a/app/neighborhoods/regency/page.tsx
+++ b/app/neighborhoods/regency/page.tsx
@@ -104,7 +104,7 @@ export default function RegencyPage() {
               Summerlin market.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Regency.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Regency.
             </p>
             <RelatedNeighborhoods currentSlug="regency" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Luxury Real Estate Market in Regency</h3>

--- a/app/neighborhoods/siena/page.tsx
+++ b/app/neighborhoods/siena/page.tsx
@@ -105,7 +105,7 @@ export default function SienaPage() {
               the factors that makes Siena one of the most desirable luxury communities in the               Las Vegas real estate market.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Siena.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Siena.
             </p>
             <RelatedNeighborhoods currentSlug="siena" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Luxury Real Estate in Siena</h3>

--- a/app/neighborhoods/summerlin-centre/page.tsx
+++ b/app/neighborhoods/summerlin-centre/page.tsx
@@ -4,6 +4,7 @@ import { BASE_URL } from '@/lib/metadata-utils'
 import Link from 'next/link'
 import HyperLocalNeighborhoodPage from '@/components/HyperLocalNeighborhoodPage'
 import RelatedNeighborhoods from '@/components/RelatedNeighborhoods'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Summerlin Centre | Modern Family Homes for Sale & Amenities',
@@ -149,6 +150,7 @@ export default function SummerlinCentrePage() {
         imageUrl="/images/summerlin-centre-hero.jpg"
         realscoutUrl="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
       />
+      <PageIndexingEnhancement path="/neighborhoods/summerlin-centre" />
     </div>
     </>
   )

--- a/app/neighborhoods/summerlin-centre/page.tsx
+++ b/app/neighborhoods/summerlin-centre/page.tsx
@@ -105,7 +105,7 @@ export default function SummerlinCentrePage() {
               buyers at various stages of life.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Summerlin Centre.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Summerlin Centre.
             </p>
             <RelatedNeighborhoods currentSlug="summerlin-centre" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Real Estate Opportunities in Summerlin Centre</h3>

--- a/app/neighborhoods/sun-city-summerlin/page.tsx
+++ b/app/neighborhoods/sun-city-summerlin/page.tsx
@@ -4,6 +4,7 @@ import { BASE_URL } from '@/lib/metadata-utils'
 import Link from 'next/link'
 import HyperLocalNeighborhoodPage from '@/components/HyperLocalNeighborhoodPage'
 import RelatedNeighborhoods from '@/components/RelatedNeighborhoods'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Sun City Summerlin | 55+ Active Adult Homes for Sale',
@@ -149,6 +150,7 @@ export default function SunCitySummerlinPage() {
         imageUrl="/images/sun-city-hero.jpg"
         realscoutUrl="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
       />
+      <PageIndexingEnhancement path="/neighborhoods/sun-city-summerlin" />
     </div>
     </>
   )

--- a/app/neighborhoods/sun-city-summerlin/page.tsx
+++ b/app/neighborhoods/sun-city-summerlin/page.tsx
@@ -106,7 +106,7 @@ export default function SunCitySummerlinPage() {
               communities for active adult real estate in Las Vegas.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Sun City Summerlin.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Sun City Summerlin.
             </p>
             <RelatedNeighborhoods currentSlug="sun-city-summerlin" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Real Estate Market in Sun City Summerlin</h3>

--- a/app/neighborhoods/the-ridges/page.tsx
+++ b/app/neighborhoods/the-ridges/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import HyperLocalNeighborhoodPage from '@/components/HyperLocalNeighborhoodPage'
 import RelatedNeighborhoods from '@/components/RelatedNeighborhoods'
 import StructuredData from '@/components/StructuredData'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'The Ridges Summerlin | Luxury Homes for Sale & Real Estate',
@@ -186,6 +187,7 @@ export default function TheRidgesPage() {
         imageUrl="/images/the-ridges-hero.jpg"
         realscoutUrl="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
       />
+      <PageIndexingEnhancement path="/neighborhoods/the-ridges" />
     </div>
     </>
   )

--- a/app/neighborhoods/the-ridges/page.tsx
+++ b/app/neighborhoods/the-ridges/page.tsx
@@ -142,7 +142,7 @@ export default function TheRidgesPage() {
               The               Ridges offers an unmatched combination of privacy, prestige, and natural beauty.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in The Ridges.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in The Ridges.
             </p>
             <RelatedNeighborhoods currentSlug="the-ridges" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Luxury Real Estate in The Ridges</h3>

--- a/app/neighborhoods/the-trails/page.tsx
+++ b/app/neighborhoods/the-trails/page.tsx
@@ -103,7 +103,7 @@ export default function TheTrailsPage() {
               The Trails a highly sought-after area for families looking to purchase               real estate in Summerlin.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in The Trails.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in The Trails.
             </p>
             <RelatedNeighborhoods currentSlug="the-trails" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Real Estate in The Trails</h3>

--- a/app/neighborhoods/willows/page.tsx
+++ b/app/neighborhoods/willows/page.tsx
@@ -104,7 +104,7 @@ export default function WillowsPage() {
               neighborhood that has already proven its value and desirability               over time.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Willows.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including homes in Willows.
             </p>
             <RelatedNeighborhoods currentSlug="willows" className="mb-4" />
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Real Estate Market in Willows</h3>

--- a/app/new-construction/page.tsx
+++ b/app/new-construction/page.tsx
@@ -115,7 +115,7 @@ export default function NewConstructionPage() {
               offer options that meet every buyer&apos;s needs and preferences in today&apos;s Las Vegas real estate market.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
-              View <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link> this weekend, including new construction showings.
+              View <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link> this weekend, including new construction showings.
             </p>
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Benefits of New Construction in Summerlin</h3>
             <p className="text-gray-700 leading-relaxed mb-4">
@@ -165,7 +165,7 @@ export default function NewConstructionPage() {
         <div className="max-w-7xl mx-auto px-4 text-center">
           <h2 className="text-2xl font-bold text-gray-900 mb-2">Tour new construction homes</h2>
           <p className="text-gray-600 mb-6">Book a time with Dr. Jan Duffy to visit model homes and new communities.</p>
-          <CalendlyPopupLink className="inline-flex items-center gap-2 bg-[#0069ff] hover:bg-[#0052cc] text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
+          <CalendlyPopupLink className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
             <Calendar className="h-5 w-5" aria-hidden />
             Schedule a private showing
           </CalendlyPopupLink>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -23,7 +23,7 @@ export default function NotFound() {
         <nav className="flex flex-col sm:flex-row gap-4 justify-center" aria-label="Helpful links">
           <Link
             href="/"
-            className="inline-flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-xl font-semibold transition-colors"
+            className="inline-flex items-center justify-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-xl font-semibold transition-colors"
           >
             <Home className="h-5 w-5" aria-hidden />
             Home

--- a/app/open-house-guide/page.tsx
+++ b/app/open-house-guide/page.tsx
@@ -7,6 +7,7 @@ import FAQAccordion from '@/components/FAQAccordion'
 import { OPEN_HOUSE_GUIDE_FAQS, OPEN_HOUSE_GUIDE_HOWTO } from '@/config/seo'
 import CalendlyPopupLink from '@/components/CalendlyPopupLink'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Open House Guide 2026 | What Buyers Need to Know | Summerlin Las Vegas',
@@ -34,7 +35,7 @@ export default function OpenHouseGuidePage() {
       <OpenHouseGuideJsonLd />
       <div className="min-h-screen bg-gray-50">
         {/* Hero */}
-        <section className="bg-gradient-to-b from-blue-600 to-blue-700 text-white py-16 px-4">
+        <section className="bg-gradient-to-b from-brand-plum to-brand-teal text-white py-16 px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h1 className="page-title-speakable text-4xl md:text-5xl font-bold mb-4">
               What to Expect at a Summerlin Open House in 2026
@@ -44,7 +45,7 @@ export default function OpenHouseGuidePage() {
             </p>
             <Link
               href="/open-houses"
-              className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors"
+              className="inline-block bg-white text-brand-plum px-8 py-3 rounded-lg font-semibold hover:bg-brand-mint/30 transition-colors"
             >
               View This Weekend&apos;s Open Houses
             </Link>
@@ -160,7 +161,7 @@ export default function OpenHouseGuidePage() {
             <p className="text-gray-600 text-center mb-8 max-w-xl mx-auto">
               Schedule a free consultation with Dr. Jan Duffy and we&apos;ll send you the Open House Touring Guide. Choose a time below—no form required.
             </p>
-            <CalendlyPopupLink className="flex items-center justify-center gap-2 w-full max-w-sm mx-auto mb-8 bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-4 rounded-xl font-bold text-lg transition-colors">
+            <CalendlyPopupLink className="flex items-center justify-center gap-2 w-full max-w-sm mx-auto mb-8 bg-brand-teal hover:bg-brand-plum text-white px-6 py-4 rounded-xl font-bold text-lg transition-colors">
               Schedule a private showing
             </CalendlyPopupLink>
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
@@ -174,8 +175,9 @@ export default function OpenHouseGuidePage() {
         </section>
 
         <p className="text-center text-sm text-gray-500 py-8">
-          Enjoyed our guide? <Link href="/review-us" className="text-blue-600 hover:underline font-medium">Leave a review on Google</Link>
+          Enjoyed our guide? <Link href="/review-us" className="text-brand-teal hover:underline font-medium">Leave a review on Google</Link>
         </p>
+        <PageIndexingEnhancement path="/open-house-guide" />
       </div>
     </>
   )

--- a/app/open-house-guide/page.tsx
+++ b/app/open-house-guide/page.tsx
@@ -66,7 +66,7 @@ export default function OpenHouseGuidePage() {
                   {'url' in step && step.url ? (
                     <>
                       {' '}
-                      <Link href={step.url} className="text-blue-600 font-semibold hover:underline">
+                      <Link href={step.url} className="text-brand-teal font-semibold hover:underline">
                         Learn more
                       </Link>
                     </>
@@ -113,7 +113,7 @@ export default function OpenHouseGuidePage() {
                   agent-buyer relationship where that agent represents you in the transaction.
                 </li>
               </ol>
-              <p className="rounded-lg bg-blue-50 border border-blue-200 p-4 font-medium text-gray-900">
+              <p className="rounded-lg bg-brand-mint/40 border border-brand-mint p-4 font-medium text-gray-900">
                 <strong>Important:</strong> Open houses remain <strong>exempt</strong> from the
                 requirement to sign a buyer agreement before viewing. You do not have to commit to
                 an agent just to walk through an open house. That&apos;s a key advantage of
@@ -129,7 +129,7 @@ export default function OpenHouseGuidePage() {
             <h2 className="text-3xl font-bold text-gray-900 mb-6">What This Means for You</h2>
             <div className="space-y-4 text-gray-700 leading-relaxed">
               <p>
-                You can still freely attend <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link>. You&apos;ll
+                You can still freely attend <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link>. You&apos;ll
                 typically be asked to sign in (digital or paper) for security and follow-up. The
                 agent at the open house represents the seller, not you.
               </p>
@@ -137,10 +137,10 @@ export default function OpenHouseGuidePage() {
                 Having your own buyer&apos;s agent gives you dedicated representation, negotiation
                 help, and access to off-market opportunities. Dr. Jan Duffy can serve as your
                 exclusive buyer&apos;s agent while you explore homes in{' '}
-                <Link href="/neighborhoods" className="text-blue-600 font-semibold hover:underline">Summerlin neighborhoods</Link> like The Ridges and Red Rock Country Club.
+                <Link href="/neighborhoods" className="text-brand-teal font-semibold hover:underline">Summerlin neighborhoods</Link> like The Ridges and Red Rock Country Club.
               </p>
               <p>
-                Questions? <Link href="/contact" className="text-blue-600 font-semibold hover:underline">Contact Dr. Jan Duffy</Link> for a no-pressure conversation about how
+                Questions? <Link href="/contact" className="text-brand-teal font-semibold hover:underline">Contact Dr. Jan Duffy</Link> for a no-pressure conversation about how
                 the new rules affect your home search.
               </p>
             </div>

--- a/app/open-house-signin/[listingId]/page.tsx
+++ b/app/open-house-signin/[listingId]/page.tsx
@@ -55,7 +55,7 @@ export default async function OpenHouseSignInPage({ params }: Props) {
           <p className="text-sm text-gray-500 mt-2">
             Dr. Jan Duffy · Berkshire Hathaway HomeServices Nevada Properties
           </p>
-          <CalendlyPopupLink className="inline-block mt-4 bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-3 rounded-xl font-semibold transition-colors">
+          <CalendlyPopupLink className="inline-block mt-4 bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-xl font-semibold transition-colors">
             Schedule a private showing
           </CalendlyPopupLink>
         </div>

--- a/app/open-houses/page.tsx
+++ b/app/open-houses/page.tsx
@@ -10,6 +10,7 @@ import {
 import Link from 'next/link'
 import RealScoutWidget from '@/components/RealScoutWidget'
 import HyperLocalNeighborhoodPage from '@/components/HyperLocalNeighborhoodPage'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
 import CalendlyPopupLink from '@/components/CalendlyPopupLink'
 import StructuredData from '@/components/StructuredData'
@@ -215,6 +216,7 @@ export default function OpenHousesPage() {
         imageUrl="/images/open-houses-hero.jpg"
         realscoutUrl="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
       />
+      <PageIndexingEnhancement path="/open-houses" />
     </div>
     </>
   )

--- a/app/open-houses/page.tsx
+++ b/app/open-houses/page.tsx
@@ -125,7 +125,7 @@ export default function OpenHousesPage() {
             </p>
             <h3 className="text-2xl font-semibold text-gray-900 mb-3">Finding the Right Open House for You</h3>
             <p className="text-gray-700 leading-relaxed mb-4">
-              Explore open houses in <Link href="/neighborhoods/the-ridges" className="text-blue-600 font-semibold hover:underline">The Ridges</Link>, <Link href="/neighborhoods/red-rock-country-club" className="text-blue-600 font-semibold hover:underline">Red Rock Country Club</Link>, <Link href="/neighborhoods/summerlin-centre" className="text-blue-600 font-semibold hover:underline">Summerlin Centre</Link>, and <Link href="/neighborhoods/sun-city-summerlin" className="text-blue-600 font-semibold hover:underline">Sun City Summerlin</Link>, or see <Link href="/neighborhoods" className="text-blue-600 font-semibold hover:underline">all Summerlin neighborhoods</Link> for community info and schools.
+              Explore open houses in <Link href="/neighborhoods/the-ridges" className="text-brand-teal font-semibold hover:underline">The Ridges</Link>, <Link href="/neighborhoods/red-rock-country-club" className="text-brand-teal font-semibold hover:underline">Red Rock Country Club</Link>, <Link href="/neighborhoods/summerlin-centre" className="text-brand-teal font-semibold hover:underline">Summerlin Centre</Link>, and <Link href="/neighborhoods/sun-city-summerlin" className="text-brand-teal font-semibold hover:underline">Sun City Summerlin</Link>, or see <Link href="/neighborhoods" className="text-brand-teal font-semibold hover:underline">all Summerlin neighborhoods</Link> for community info and schools.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
               Summerlin&apos;s open house market includes properties across all price points and neighborhoods, from entry-level 
@@ -133,7 +133,7 @@ export default function OpenHousesPage() {
               Our open house listings are updated regularly to provide the most current information about available properties, 
               including times, dates, and property details. With a median home price of $750,000 and 85 active listings, 
               Summerlin offers diverse opportunities for buyers at every stage of their real estate journey.{' '}
-              <CalendlyPopupLink className="text-blue-600 font-semibold hover:underline">Schedule a private showing</CalendlyPopupLink> to get personalized open house recommendations.
+              <CalendlyPopupLink className="text-brand-teal font-semibold hover:underline">Schedule a private showing</CalendlyPopupLink> to get personalized open house recommendations.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
               When attending open houses in Summerlin, consider not just the property itself but also the neighborhood, 
@@ -175,7 +175,7 @@ export default function OpenHousesPage() {
           </h2>
           <p className="mb-8 text-center text-gray-600">
             Live MLS listings from Dr. Jan Duffy&apos;s office (sorted low to high, $400K–$900K — same range as the site-wide office bands). For the full search experience, visit{' '}
-            <Link href="/tour/mls" className="font-semibold text-blue-600 hover:underline">
+            <Link href="/tour/mls" className="font-semibold text-brand-teal hover:underline">
               MLS property search
             </Link>
             .
@@ -202,9 +202,9 @@ export default function OpenHousesPage() {
         </div>
       </section>
       <p className="text-center text-sm text-gray-500 mb-8">
-        Enjoyed your visit? <Link href="/review-us" className="text-blue-600 hover:underline font-medium">Leave a review on Google</Link>
+        Enjoyed your visit? <Link href="/review-us" className="text-brand-teal hover:underline font-medium">Leave a review on Google</Link>
         {' · '}
-        <Link href="/sitemap" className="text-blue-600 hover:underline font-medium">Sitemap</Link>
+        <Link href="/sitemap" className="text-brand-teal hover:underline font-medium">Sitemap</Link>
       </p>
       <HyperLocalNeighborhoodPage
         name={SEO_PRIMARY_KEYWORD}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import {
 import SummerlinOpenHouseWebsite from "components/SummerlinOpenHouseWebsite"
 import StructuredData from "@/components/StructuredData"
 import GoogleMyMapsSection from "@/components/GoogleMyMapsSection"
+import PageIndexingEnhancement from "@/components/PageIndexingEnhancement"
 
 export const revalidate = 3600 // ISR: revalidate every hour
 
@@ -71,6 +72,7 @@ export default function HomePage() {
           />
         </div>
       </div>
+      <PageIndexingEnhancement path="/" />
     </main>
   )
 }

--- a/app/resources/[slug]/page.tsx
+++ b/app/resources/[slug]/page.tsx
@@ -197,7 +197,7 @@ const validResources: Record<string, {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div>
               <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                <Link href="/builders/toll-brothers" className="text-blue-600 hover:text-blue-800">
+                <Link href="/builders/toll-brothers" className="text-brand-teal hover:text-brand-plum">
                   Toll Brothers
                 </Link>
               </h3>
@@ -205,7 +205,7 @@ const validResources: Record<string, {
             </div>
             <div>
               <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                <Link href="/builders/lennar" className="text-blue-600 hover:text-blue-800">
+                <Link href="/builders/lennar" className="text-brand-teal hover:text-brand-plum">
                   Lennar
                 </Link>
               </h3>
@@ -213,7 +213,7 @@ const validResources: Record<string, {
             </div>
             <div>
               <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                <Link href="/builders/pulte" className="text-blue-600 hover:text-blue-800">
+                <Link href="/builders/pulte" className="text-brand-teal hover:text-brand-plum">
                   Pulte Homes
                 </Link>
               </h3>
@@ -317,7 +317,7 @@ export default async function ResourcePage({ params }: ResourcePageProps) {
       />
       <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-blue-600 to-red-600">
+      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-brand-teal to-brand-plum">
         <div className="absolute inset-0 bg-black bg-opacity-40" />
         <div className="absolute inset-0 flex items-center justify-center text-center">
           <div className="max-w-4xl mx-auto px-4">
@@ -364,7 +364,7 @@ export default async function ResourcePage({ params }: ResourcePageProps) {
                         {'url' in step && step.url ? (
                           <>
                             {' '}
-                            <Link href={step.url} className="text-blue-600 font-semibold hover:underline">
+                            <Link href={step.url} className="text-brand-teal font-semibold hover:underline">
                               Learn more
                             </Link>
                           </>
@@ -407,12 +407,12 @@ export default async function ResourcePage({ params }: ResourcePageProps) {
         </div>
 
         {/* CTA */}
-        <div className="bg-blue-600 rounded-lg shadow-md p-8 text-center text-white">
+        <div className="bg-brand-teal rounded-lg shadow-md p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Ready to Get Started?</h2>
           <p className="text-xl mb-6">Contact us for personalized assistance with your real estate needs</p>
           <Link
             href="/contact"
-            className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
+            className="inline-block bg-white text-brand-teal px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
           >
             Contact Dr. Jan Duffy
           </Link>

--- a/app/review-us/page.tsx
+++ b/app/review-us/page.tsx
@@ -51,7 +51,7 @@ export default function ReviewUsPage() {
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-14">
         <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
           <ol className="flex flex-wrap gap-x-2 gap-y-1">
-            <li><Link href="/" className="hover:text-blue-600 transition-colors">Home</Link></li>
+            <li><Link href="/" className="hover:text-brand-plum transition-colors">Home</Link></li>
             <li aria-hidden>/</li>
             <li className="text-gray-700 font-medium" aria-current="page">Review us on Google</li>
           </ol>
@@ -76,7 +76,7 @@ export default function ReviewUsPage() {
           </p>
           <ExternalLink
             href={REVIEW_URL}
-            className="inline-flex items-center gap-2 bg-[#4285F4] hover:bg-[#3367D6] text-white px-6 py-3 rounded-lg font-semibold transition-colors"
+            className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-lg font-semibold transition-colors"
             showIcon={false}
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden>
@@ -100,7 +100,7 @@ export default function ReviewUsPage() {
           <div className="flex flex-wrap gap-4">
             <ExternalLink
               href={whatsappShareUrl}
-              className="inline-flex items-center gap-2 bg-[#25D366] hover:bg-[#20BD5A] text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
+              className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
               ariaLabel="Share review link on WhatsApp"
               showIcon={false}
             >
@@ -111,7 +111,7 @@ export default function ReviewUsPage() {
             </ExternalLink>
             <ExternalLink
               href={facebookShareUrl}
-              className="inline-flex items-center gap-2 bg-[#1877F2] hover:bg-[#166FE5] text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
+              className="inline-flex items-center gap-2 bg-brand-plum hover:bg-brand-teal text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
               ariaLabel="Share review link on Facebook"
               showIcon={false}
             >
@@ -131,7 +131,7 @@ export default function ReviewUsPage() {
           <div className="flex flex-col items-center mt-6">
             <ExternalLink
               href={REVIEW_URL}
-              className="block focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-lg"
+              className="block focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-2 rounded-lg"
               ariaLabel="Open Google review page for Dr. Jan Duffy Real Estate"
               showIcon={false}
             >
@@ -157,7 +157,7 @@ export default function ReviewUsPage() {
             <li>
               <ExternalLink
                 href={GOOGLE_REVIEW_GUIDE}
-                className="text-blue-600 hover:underline font-medium"
+                className="text-brand-teal hover:underline font-medium"
                 ariaLabel="Share a link or QR code to request reviews (Google Help)"
               >
                 Share a link or QR code to request reviews (Google Help)
@@ -166,7 +166,7 @@ export default function ReviewUsPage() {
             <li>
               <ExternalLink
                 href={GOOGLE_TIPS_REVIEWS}
-                className="text-blue-600 hover:underline font-medium"
+                className="text-brand-teal hover:underline font-medium"
                 ariaLabel="Tips to get more reviews (Google Help)"
               >
                 Tips to get more reviews (Google Help)
@@ -176,7 +176,7 @@ export default function ReviewUsPage() {
         </section>
 
         <p className="mt-8 text-center">
-          <Link href="/contact" className="text-blue-600 hover:underline font-medium">
+          <Link href="/contact" className="text-brand-teal hover:underline font-medium">
             Contact Dr. Jan Duffy
           </Link>
         </p>

--- a/app/schedule-consultation/page.tsx
+++ b/app/schedule-consultation/page.tsx
@@ -52,7 +52,7 @@ export default function ScheduleConsultationPage() {
           <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
             <ol className="flex flex-wrap gap-x-2 gap-y-1">
               <li>
-                <Link href="/" className="hover:text-blue-600 transition-colors">
+                <Link href="/" className="hover:text-brand-plum transition-colors">
                   Home
                 </Link>
               </li>
@@ -70,7 +70,7 @@ export default function ScheduleConsultationPage() {
             <p className="text-lg text-gray-600 max-w-xl mx-auto mb-6">
               Discuss your real estate goals with Dr. Jan Duffy—buying, selling, or scheduling a private showing. No obligation.
             </p>
-            <CalendlyPopupLink className="inline-flex items-center justify-center bg-[#0069ff] hover:bg-[#0052cc] text-white px-8 py-4 rounded-xl font-bold text-lg transition-colors shadow-lg">
+            <CalendlyPopupLink className="inline-flex items-center justify-center bg-brand-teal hover:bg-brand-plum text-white px-8 py-4 rounded-xl font-bold text-lg transition-colors shadow-lg">
               Schedule a free consultation
             </CalendlyPopupLink>
           </header>
@@ -85,11 +85,11 @@ export default function ScheduleConsultationPage() {
           </section>
 
           <p className="mt-6 text-center text-sm text-gray-500">
-            Prefer to call? <a href="tel:+17022003422" className="text-blue-600 hover:underline">(702) 200-3422</a>
+            Prefer to call? <a href="tel:+17022003422" className="text-brand-teal hover:underline">(702) 200-3422</a>
             {' · '}
-            <Link href="/book-tour" className="text-blue-600 hover:underline">Schedule a private showing</Link>
+            <Link href="/book-tour" className="text-brand-teal hover:underline">Schedule a private showing</Link>
             {' · '}
-            <Link href="/review-us" className="text-blue-600 hover:underline">Review us on Google</Link>
+            <Link href="/review-us" className="text-brand-teal hover:underline">Review us on Google</Link>
           </p>
         </div>
       </main>

--- a/app/schedule-consultation/page.tsx
+++ b/app/schedule-consultation/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
 import CalendlyPopupLink from '@/components/CalendlyPopupLink'
 import StructuredData from '@/components/StructuredData'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Schedule a Free Consultation | Dr. Jan Duffy Real Estate',
@@ -92,6 +93,7 @@ export default function ScheduleConsultationPage() {
           </p>
         </div>
       </main>
+      <PageIndexingEnhancement path="/schedule-consultation" />
     </>
   )
 }

--- a/app/schools/page.tsx
+++ b/app/schools/page.tsx
@@ -83,7 +83,7 @@ export default function SchoolsPage() {
       />
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-blue-600 to-red-600">
+      <section className="relative h-[40vh] min-h-[300px] bg-gradient-to-r from-brand-teal to-brand-plum">
         <div className="absolute inset-0 bg-black bg-opacity-40" />
         <div className="absolute inset-0 flex items-center justify-center text-center">
           <div className="max-w-4xl mx-auto px-4">
@@ -136,7 +136,7 @@ export default function SchoolsPage() {
                   <h3 className="text-2xl font-bold text-gray-900 mb-1">{school.name}</h3>
                   <p className="text-gray-600">{school.type}</p>
                 </div>
-                <div className="flex items-center bg-blue-100 text-blue-800 px-3 py-1 rounded-full">
+                <div className="flex items-center bg-brand-mint text-brand-plum px-3 py-1 rounded-full">
                   <Award className="h-4 w-4 mr-1" />
                   <span className="font-semibold">{school.rating}/10</span>
                 </div>
@@ -144,15 +144,15 @@ export default function SchoolsPage() {
 
               <div className="space-y-3 mb-4">
                 <div className="flex items-center text-gray-600">
-                  <BookOpen className="h-5 w-5 mr-2 text-blue-600" />
+                  <BookOpen className="h-5 w-5 mr-2 text-brand-teal" />
                   <span>Grades: {school.grades}</span>
                 </div>
                 <div className="flex items-center text-gray-600">
-                  <Users className="h-5 w-5 mr-2 text-blue-600" />
+                  <Users className="h-5 w-5 mr-2 text-brand-teal" />
                   <span>Enrollment: {school.enrollment.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center text-gray-600">
-                  <School className="h-5 w-5 mr-2 text-blue-600" />
+                  <School className="h-5 w-5 mr-2 text-brand-teal" />
                   <span>Distance: {school.distance}</span>
                 </div>
               </div>
@@ -244,20 +244,20 @@ export default function SchoolsPage() {
               Use our detailed zip code pages to explore schools serving specific areas within Summerlin West:
             </p>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <Link href="/zip/89135" className="block bg-blue-50 p-4 rounded-lg hover:bg-blue-100 transition-colors">
+              <Link href="/zip/89135" className="block bg-brand-mint/40 p-4 rounded-lg hover:bg-brand-mint transition-colors">
                 <h4 className="font-semibold text-gray-900 mb-2">Zip Code 89135</h4>
                 <p className="text-sm text-gray-600">The Ridges, Red Rock Country Club</p>
-                <span className="text-blue-600 text-sm mt-2 inline-block">View Schools →</span>
+                <span className="text-brand-teal text-sm mt-2 inline-block">View Schools →</span>
               </Link>
-              <Link href="/zip/89138" className="block bg-blue-50 p-4 rounded-lg hover:bg-blue-100 transition-colors">
+              <Link href="/zip/89138" className="block bg-brand-mint/40 p-4 rounded-lg hover:bg-brand-mint transition-colors">
                 <h4 className="font-semibold text-gray-900 mb-2">Zip Code 89138</h4>
                 <p className="text-sm text-gray-600">Summerlin Centre, The Trails</p>
-                <span className="text-blue-600 text-sm mt-2 inline-block">View Schools →</span>
+                <span className="text-brand-teal text-sm mt-2 inline-block">View Schools →</span>
               </Link>
-              <Link href="/zip/89144" className="block bg-blue-50 p-4 rounded-lg hover:bg-blue-100 transition-colors">
+              <Link href="/zip/89144" className="block bg-brand-mint/40 p-4 rounded-lg hover:bg-brand-mint transition-colors">
                 <h4 className="font-semibold text-gray-900 mb-2">Zip Code 89144</h4>
                 <p className="text-sm text-gray-600">Sun City Summerlin</p>
-                <span className="text-blue-600 text-sm mt-2 inline-block">View Schools →</span>
+                <span className="text-brand-teal text-sm mt-2 inline-block">View Schools →</span>
               </Link>
             </div>
           </div>
@@ -306,17 +306,17 @@ export default function SchoolsPage() {
         </div>
 
         {/* CTA */}
-        <div className="bg-blue-600 rounded-lg shadow-md p-8 text-center text-white">
+        <div className="bg-brand-teal rounded-lg shadow-md p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Find the Perfect Home Near Great Schools</h2>
           <p className="text-xl mb-6">Let us help you find a home in the right school district for your family.</p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/contact"
-              className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
+              className="inline-block bg-white text-brand-teal px-8 py-3 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors"
             >
               Get Started Today
             </Link>
-            <CalendlyPopupLink className="inline-flex items-center gap-2 bg-[#0069ff] hover:bg-[#0052cc] text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
+            <CalendlyPopupLink className="inline-flex items-center gap-2 bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-bold text-lg transition-colors">
               <Calendar className="h-5 w-5" aria-hidden />
               Schedule a private showing
             </CalendlyPopupLink>

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -68,15 +68,15 @@ export default function SitemapPage() {
           <section>
             <h2 className="text-2xl font-bold text-gray-900 mb-4">Main Pages</h2>
             <ul className="space-y-2">
-              <li><Link href="/" className="text-blue-600 hover:text-blue-800">Home</Link></li>
-              <li><Link href="/open-houses" className="text-blue-600 hover:text-blue-800">Open Houses</Link></li>
-              <li><Link href="/market-report" className="text-blue-600 hover:text-blue-800">Market Report</Link></li>
-              <li><Link href="/schools" className="text-blue-600 hover:text-blue-800">Schools</Link></li>
-              <li><Link href="/contact" className="text-blue-600 hover:text-blue-800">Contact</Link></li>
-              <li><Link href="/review-us" className="text-blue-600 hover:text-blue-800">Review us on Google</Link></li>
-              <li><Link href="/about" className="text-blue-600 hover:text-blue-800">About</Link></li>
-              <li><Link href="/luxury-homes" className="text-blue-600 hover:text-blue-800">Luxury Homes</Link></li>
-              <li><Link href="/new-construction" className="text-blue-600 hover:text-blue-800">New Construction</Link></li>
+              <li><Link href="/" className="text-brand-teal hover:text-brand-plum">Home</Link></li>
+              <li><Link href="/open-houses" className="text-brand-teal hover:text-brand-plum">Open Houses</Link></li>
+              <li><Link href="/market-report" className="text-brand-teal hover:text-brand-plum">Market Report</Link></li>
+              <li><Link href="/schools" className="text-brand-teal hover:text-brand-plum">Schools</Link></li>
+              <li><Link href="/contact" className="text-brand-teal hover:text-brand-plum">Contact</Link></li>
+              <li><Link href="/review-us" className="text-brand-teal hover:text-brand-plum">Review us on Google</Link></li>
+              <li><Link href="/about" className="text-brand-teal hover:text-brand-plum">About</Link></li>
+              <li><Link href="/luxury-homes" className="text-brand-teal hover:text-brand-plum">Luxury Homes</Link></li>
+              <li><Link href="/new-construction" className="text-brand-teal hover:text-brand-plum">New Construction</Link></li>
             </ul>
           </section>
 
@@ -86,7 +86,7 @@ export default function SitemapPage() {
             <ul className="grid grid-cols-1 md:grid-cols-2 gap-2">
               {neighborhoods.map((neighborhood) => (
                 <li key={neighborhood.url}>
-                  <Link href={neighborhood.url} className="text-blue-600 hover:text-blue-800">
+                  <Link href={neighborhood.url} className="text-brand-teal hover:text-brand-plum">
                     {neighborhood.name}
                   </Link>
                 </li>
@@ -100,7 +100,7 @@ export default function SitemapPage() {
             <ul className="space-y-2">
               {zipCodes.map((zip) => (
                 <li key={zip.url}>
-                  <Link href={zip.url} className="text-blue-600 hover:text-blue-800">
+                  <Link href={zip.url} className="text-brand-teal hover:text-brand-plum">
                     Zip Code {zip.code}
                   </Link>
                 </li>
@@ -114,7 +114,7 @@ export default function SitemapPage() {
             <ul className="space-y-2">
               {resources.map((resource) => (
                 <li key={resource.url}>
-                  <Link href={resource.url} className="text-blue-600 hover:text-blue-800">
+                  <Link href={resource.url} className="text-brand-teal hover:text-brand-plum">
                     {resource.name}
                   </Link>
                 </li>
@@ -128,7 +128,7 @@ export default function SitemapPage() {
             <ul className="space-y-2">
               {builders.map((builder) => (
                 <li key={builder.url}>
-                  <Link href={builder.url} className="text-blue-600 hover:text-blue-800">
+                  <Link href={builder.url} className="text-brand-teal hover:text-brand-plum">
                     {builder.name}
                   </Link>
                 </li>
@@ -140,9 +140,9 @@ export default function SitemapPage() {
           <section>
             <h2 className="text-2xl font-bold text-gray-900 mb-4">Legal</h2>
             <ul className="space-y-2">
-              <li><Link href="/privacy-policy" className="text-blue-600 hover:text-blue-800">Privacy Policy</Link></li>
-              <li><Link href="/terms-of-service" className="text-blue-600 hover:text-blue-800">Terms of Service</Link></li>
-              <li><Link href="/disclaimer" className="text-blue-600 hover:text-blue-800">Disclaimer</Link></li>
+              <li><Link href="/privacy-policy" className="text-brand-teal hover:text-brand-plum">Privacy Policy</Link></li>
+              <li><Link href="/terms-of-service" className="text-brand-teal hover:text-brand-plum">Terms of Service</Link></li>
+              <li><Link href="/disclaimer" className="text-brand-teal hover:text-brand-plum">Disclaimer</Link></li>
             </ul>
           </section>
         </div>

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { BASE_URL, DEFAULT_OG_IMAGE_PATHS } from '@/lib/metadata-utils'
 
 import Link from 'next/link'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Sitemap | Open House Market Place',
@@ -147,6 +148,7 @@ export default function SitemapPage() {
         </div>
       </div>
     </div>
+    <PageIndexingEnhancement path="/sitemap" />
     </>
   )
 }

--- a/app/store-locations/page.tsx
+++ b/app/store-locations/page.tsx
@@ -7,6 +7,7 @@ import StoreLocationsMap from '@/components/StoreLocationsMap'
 import CalendlyInlineWidget from '@/components/CalendlyInlineWidget'
 import GoogleMyMapsSection from '@/components/GoogleMyMapsSection'
 import StructuredData from '@/components/StructuredData'
+import PageIndexingEnhancement from '@/components/PageIndexingEnhancement'
 
 export const metadata: Metadata = {
   title: 'Find Our Stores | Store Locations & Map | Dr. Jan Duffy Real Estate',
@@ -111,6 +112,7 @@ export default function StoreLocationsPage() {
           </div>
         </div>
       </main>
+      <PageIndexingEnhancement path="/store-locations" />
     </>
   )
 }

--- a/app/store-locations/page.tsx
+++ b/app/store-locations/page.tsx
@@ -54,7 +54,7 @@ export default function StoreLocationsPage() {
           <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
             <ol className="flex flex-wrap gap-x-2 gap-y-1">
               <li>
-                <Link href="/" className="hover:text-blue-600 transition-colors">
+                <Link href="/" className="hover:text-brand-plum transition-colors">
                   Home
                 </Link>
               </li>

--- a/app/test-form/page.tsx
+++ b/app/test-form/page.tsx
@@ -30,7 +30,7 @@ export default function TestForm() {
 
       <h2 className="text-xl font-semibold mb-2">Schedule a private showing</h2>
       <p className="text-gray-600 mb-4">Book a private showing or consultation with Dr. Jan Duffy.</p>
-      <CalendlyPopupLink className="inline-block bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-3 rounded-xl font-semibold mb-6">
+      <CalendlyPopupLink className="inline-block bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-xl font-semibold mb-6">
         Schedule a private showing
       </CalendlyPopupLink>
 
@@ -44,7 +44,7 @@ export default function TestForm() {
       <div className="space-y-4 mb-6">
         <button
           onClick={testEnv}
-          className="bg-blue-500 text-white px-4 py-2 rounded"
+          className="bg-brand-teal text-white px-4 py-2 rounded"
         >
           Test Environment Variables
         </button>

--- a/app/tour/mls/page.tsx
+++ b/app/tour/mls/page.tsx
@@ -38,7 +38,7 @@ export default function TourMLSPage() {
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold text-gray-900 mb-4">MLS Property Search</h1>
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-              Search the full MLS database of homes for sale in Summerlin. Save favorites, get alerts, and schedule showings with Dr. Jan Duffy&apos;s home search. For this weekend&apos;s tours, see our <Link href="/open-houses" className="text-blue-600 font-semibold hover:underline">Summerlin open houses</Link>.
+              Search the full MLS database of homes for sale in Summerlin. Save favorites, get alerts, and schedule showings with Dr. Jan Duffy&apos;s home search. For this weekend&apos;s tours, see our <Link href="/open-houses" className="text-brand-teal font-semibold hover:underline">Summerlin open houses</Link>.
             </p>
           </div>
 
@@ -58,12 +58,12 @@ export default function TourMLSPage() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8">
             <ExternalLink
               href={REALSCOUT_SEARCH_URL}
-              className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold"
+              className="inline-block bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-lg font-semibold"
               showIcon={false}
             >
               Open full search in new tab
             </ExternalLink>
-            <Link href="/contact" className="inline-block text-gray-700 hover:text-blue-600 font-medium">
+            <Link href="/contact" className="inline-block text-gray-700 hover:text-brand-plum font-medium">
               Contact Dr. Jan Duffy
             </Link>
           </div>

--- a/components/AmenityMap.tsx
+++ b/components/AmenityMap.tsx
@@ -189,7 +189,7 @@ export default function AmenityMap() {
     <div className="relative w-full">
       <div className="flex flex-wrap gap-2 mb-4 p-3 bg-gray-50 rounded-lg border border-gray-200">
         <span className="text-sm font-medium text-gray-700 flex items-center gap-1.5 w-full sm:w-auto">
-          <MapPin className="h-4 w-4 text-blue-600" aria-hidden />
+          <MapPin className="h-4 w-4 text-brand-teal" aria-hidden />
           Show nearby:
         </span>
         {AMENITY_TYPES.map(({ type, label, icon }) => (
@@ -197,8 +197,8 @@ export default function AmenityMap() {
             key={type}
             className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer text-sm font-medium transition-colors ${
               selectedTypes.has(type)
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-700 border-gray-300 hover:border-blue-400'
+                ? 'bg-brand-teal text-white border-brand-teal'
+                : 'bg-white text-gray-700 border-gray-300 hover:border-brand-teal'
             }`}
           >
             <input
@@ -218,7 +218,7 @@ export default function AmenityMap() {
         aria-label="Map showing nearby amenities"
       />
       {noResultsForCurrentSelection && (
-        <p className="mt-3 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2" role="status">
+        <p className="mt-3 text-sm text-brand-plum bg-brand-mint/40 border border-brand-mint rounded-lg px-3 py-2" role="status">
           No places found in this area. Try different types or zoom out.
         </p>
       )}
@@ -230,7 +230,7 @@ export default function AmenityMap() {
           aria-label="Loading map"
         >
           <div className="text-center">
-            <div className="animate-spin rounded-full h-10 w-10 border-2 border-blue-600 border-t-transparent mx-auto mb-3" />
+            <div className="animate-spin rounded-full h-10 w-10 border-2 border-brand-teal border-t-transparent mx-auto mb-3" />
             <p className="text-sm text-gray-600">Loading map...</p>
           </div>
         </div>
@@ -245,7 +245,7 @@ export default function AmenityMap() {
           <button
             type="button"
             onClick={handleRetry}
-            className="px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="px-4 py-2 bg-brand-teal text-white font-medium rounded-lg hover:bg-brand-plum focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-2"
           >
             Retry
           </button>

--- a/components/Button/Button.test.tsx
+++ b/components/Button/Button.test.tsx
@@ -16,7 +16,7 @@ describe("Button", () => {
     )
     const link = container.querySelector("a")
     expect(link).toHaveClass("bg-transparent")
-    expect(link).toHaveClass("text-blue-400")
+    expect(link).toHaveClass("text-brand-teal")
   })
 
   it("applies correct size classes", () => {

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -10,15 +10,15 @@ const button = cva(
     "rounded-xl",
     "text-center",
     "border",
-    "border-blue-400",
+    "border-brand-teal",
     "transition-colors",
     "delay-50",
   ],
   {
     variants: {
       intent: {
-        primary: ["bg-blue-400", "text-white", "hover:enabled:bg-blue-700"],
-        secondary: ["bg-transparent", "text-blue-400", "hover:enabled:bg-blue-400", "hover:enabled:text-white"],
+        primary: ["bg-brand-teal", "text-white", "hover:enabled:bg-brand-plum"],
+        secondary: ["bg-transparent", "text-brand-teal", "hover:enabled:bg-brand-teal", "hover:enabled:text-white"],
       },
       size: {
         sm: ["min-w-20", "h-full", "min-h-10", "text-sm", "py-1.5", "px-4"],

--- a/components/BuyerToolsSection.tsx
+++ b/components/BuyerToolsSection.tsx
@@ -35,7 +35,7 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
     <section className="py-16 bg-gradient-to-b from-white to-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <div className="inline-flex items-center bg-blue-100 text-blue-800 px-4 py-2 rounded-full text-sm font-medium mb-4">
+          <div className="inline-flex items-center bg-brand-mint text-brand-plum px-4 py-2 rounded-full text-sm font-medium mb-4">
             <svg className="h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
@@ -50,7 +50,7 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Mortgage Calculator */}
           <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
-            <div className="bg-gradient-to-r from-green-500 to-green-600 p-4">
+            <div className="bg-gradient-to-r from-brand-teal to-brand-plum p-4">
               <h3 className="text-white font-bold text-lg flex items-center">
                 <svg className="h-6 w-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -67,7 +67,7 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
                     type="number"
                     value={selectedPrice}
                     onChange={(e) => setSelectedPrice(Number(e.target.value))}
-                    className="w-full pl-8 pr-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                    className="w-full pl-8 pr-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-teal focus:border-brand-teal"
                     aria-label="Home price"
                     placeholder="e.g. 875000"
                   />
@@ -81,7 +81,7 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
                       type="number"
                       value={downPayment}
                       onChange={(e) => setDownPayment(Number(e.target.value))}
-                      className="w-full pr-8 pl-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500"
+                      className="w-full pr-8 pl-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-teal"
                       aria-label="Down payment percentage"
                       placeholder="20"
                     />
@@ -96,7 +96,7 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
                       value={interestRate}
                       step="0.1"
                       onChange={(e) => setInterestRate(Number(e.target.value))}
-                      className="w-full pr-8 pl-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500"
+                      className="w-full pr-8 pl-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-teal"
                       aria-label="Interest rate"
                       placeholder="7.0"
                     />
@@ -104,18 +104,18 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
                   </div>
                 </div>
               </div>
-              <div className="bg-green-50 rounded-lg p-4 text-center">
+              <div className="bg-brand-mint/40 rounded-lg p-4 text-center">
                 <div className="text-sm text-gray-600 mb-1">Estimated Monthly Payment</div>
-                <div className="text-3xl font-bold text-green-600">${calculateMonthly()}</div>
+                <div className="text-3xl font-bold text-brand-teal">${calculateMonthly()}</div>
                 <div className="text-xs text-gray-500 mt-2">*Excludes taxes, insurance, and HOA</div>
               </div>
-              <button className="w-full mt-4 bg-green-600 hover:bg-green-700 text-white font-medium py-3 rounded-lg transition-colors">Get Pre-Approved Today</button>
+              <button className="w-full mt-4 bg-brand-teal hover:bg-brand-plum text-white font-medium py-3 rounded-lg transition-colors">Get Pre-Approved Today</button>
             </div>
           </div>
 
           {/* School Finder */}
           <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
-            <div className="bg-gradient-to-r from-blue-500 to-blue-600 p-4">
+            <div className="bg-gradient-to-r from-brand-teal to-brand-plum p-4">
               <h3 className="text-white font-bold text-lg flex items-center">
                 <svg className="h-6 w-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path d="M12 14l9-5-9-5-9 5 9 5z" />
@@ -134,27 +134,27 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
                       <div className="text-sm text-gray-600">{school.type} • {school.distance}</div>
                     </div>
                     <div className="flex items-center">
-                      <div className="text-2xl font-bold text-blue-600 mr-1">{school.rating}</div>
+                      <div className="text-2xl font-bold text-brand-teal mr-1">{school.rating}</div>
                       <div className="text-sm text-gray-500">/10</div>
                     </div>
                   </div>
                 ))}
               </div>
-              <div className="mt-4 p-3 bg-blue-50 rounded-lg">
-                <div className="flex items-center text-sm text-blue-800">
+              <div className="mt-4 p-3 bg-brand-mint/40 rounded-lg">
+                <div className="flex items-center text-sm text-brand-plum">
                   <svg className="h-4 w-4 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                     <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                   </svg>
                   All schools ranked in top 20% statewide
                 </div>
               </div>
-              <button className="w-full mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 rounded-lg transition-colors">View Full School Report</button>
+              <button className="w-full mt-4 bg-brand-teal hover:bg-brand-plum text-white font-medium py-3 rounded-lg transition-colors">View Full School Report</button>
             </div>
           </div>
 
           {/* Instant Booking */}
           <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow">
-            <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-4">
+            <div className="bg-gradient-to-r from-brand-teal to-brand-plum p-4">
               <h3 className="text-white font-bold text-lg flex items-center">
                 <svg className="h-6 w-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -164,25 +164,25 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
             </div>
             <div className="p-6">
               <div className="text-center mb-6">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-purple-100 rounded-full mb-4"><span className="text-2xl">🏠</span></div>
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-brand-mint rounded-full mb-4"><span className="text-2xl">🏠</span></div>
                 <h4 className="font-bold text-gray-900 mb-2">This Weekend's Open Houses</h4>
                 <p className="text-gray-600 text-sm">6 homes available for viewing</p>
               </div>
               <div className="space-y-3 mb-6">
-                <div className="flex items-center p-3 bg-purple-50 rounded-lg">
-                  <div className="flex-shrink-0 w-2 h-2 bg-purple-600 rounded-full mr-3"></div>
+                <div className="flex items-center p-3 bg-brand-mint/40 rounded-lg">
+                  <div className="flex-shrink-0 w-2 h-2 bg-brand-teal rounded-full mr-3"></div>
                   <div className="flex-1"><div className="text-sm font-medium">Saturday</div><div className="text-xs text-gray-600">4 homes • 10am - 4pm</div></div>
                 </div>
-                <div className="flex items-center p-3 bg-purple-50 rounded-lg">
-                  <div className="flex-shrink-0 w-2 h-2 bg-purple-600 rounded-full mr-3"></div>
+                <div className="flex items-center p-3 bg-brand-mint/40 rounded-lg">
+                  <div className="flex-shrink-0 w-2 h-2 bg-brand-teal rounded-full mr-3"></div>
                   <div className="flex-1"><div className="text-sm font-medium">Sunday</div><div className="text-xs text-gray-600">2 homes • 11am - 3pm</div></div>
                 </div>
               </div>
-              <button className="w-full bg-purple-600 hover:bg-purple-700 text-white font-medium py-3 rounded-lg transition-colors mb-3">Book Your Viewings</button>
-              <button className="w-full bg-purple-100 hover:bg-purple-200 text-purple-700 font-medium py-3 rounded-lg transition-colors">Get Virtual Tour First</button>
+              <button className="w-full bg-brand-teal hover:bg-brand-plum text-white font-medium py-3 rounded-lg transition-colors mb-3">Book Your Viewings</button>
+              <button className="w-full bg-brand-mint hover:bg-brand-mint text-brand-plum font-medium py-3 rounded-lg transition-colors">Get Virtual Tour First</button>
               <div className="mt-4 text-center">
                 <div className="inline-flex items-center text-xs text-gray-600">
-                  <svg className="h-4 w-4 mr-1 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                  <svg className="h-4 w-4 mr-1 text-brand-teal" fill="currentColor" viewBox="0 0 20 20">
                     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                   </svg>
                   247 viewings booked this week
@@ -196,11 +196,11 @@ export default function BuyerToolsSection({ searchListingsHref }: BuyerToolsSect
         <div className="mt-12 text-center">
           <div className="inline-flex flex-col sm:flex-row gap-4 items-center">
             {searchListingsHref ? (
-              <Link href={searchListingsHref} className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-lg font-medium transition-colors">
+              <Link href={searchListingsHref} className="bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-medium transition-colors">
                 Start Your Home Search
               </Link>
             ) : (
-              <button className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-lg font-medium transition-colors">Start Your Home Search</button>
+              <button className="bg-brand-teal hover:bg-brand-plum text-white px-8 py-3 rounded-lg font-medium transition-colors">Start Your Home Search</button>
             )}
             <div className="flex items-center text-sm text-gray-600">
               <svg className="h-5 w-5 mr-2 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">

--- a/components/CalendlyBadgeWidget.tsx
+++ b/components/CalendlyBadgeWidget.tsx
@@ -11,7 +11,7 @@ const CALENDLY_SCRIPT = 'https://assets.calendly.com/assets/external/widget.js'
 const BADGE_CONFIG = {
   url: CALENDLY_OPEN_HOUSE_TOUR_URL,
   text: 'Schedule a private showing',
-  color: '#0069ff',
+  color: '#6399a3',
   textColor: '#ffffff',
   branding: true,
 } as const

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -125,17 +125,17 @@ const ContactForm: React.FC<ContactFormProps> = ({
       
       {/* Success Message */}
       {submitStatus === 'success' && (
-        <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center">
-          <CheckCircle className="h-5 w-5 text-green-500 mr-3" />
-          <span className="text-green-800">Thank you! Your message has been sent. We'll get back to you soon.</span>
+        <div className="mb-6 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg flex items-center">
+          <CheckCircle className="h-5 w-5 text-brand-teal mr-3" />
+          <span className="text-brand-plum">Thank you! Your message has been sent. We'll get back to you soon.</span>
         </div>
       )}
 
       {/* Error Message */}
       {submitStatus === 'error' && (
-        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center">
-          <AlertCircle className="h-5 w-5 text-red-500 mr-3" />
-          <span className="text-red-800">{errorMessage}</span>
+        <div className="mb-6 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg flex items-center">
+          <AlertCircle className="h-5 w-5 text-brand-teal mr-3" />
+          <span className="text-brand-plum">{errorMessage}</span>
         </div>
       )}
       
@@ -151,12 +151,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
               type="text"
               placeholder="Your Name"
               className={`w-full pl-10 pr-4 py-2 rounded-lg border text-gray-900 placeholder-gray-500 focus:outline-none ${
-                errors.name ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+                errors.name ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.name && (
-            <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.name.message}</p>
           )}
         </div>
         
@@ -174,12 +174,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
               type="email"
               placeholder="Email Address"
               className={`w-full pl-10 pr-4 py-2 rounded-lg border text-gray-900 placeholder-gray-500 focus:outline-none ${
-                errors.email ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+                errors.email ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.email && (
-            <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.email.message}</p>
           )}
         </div>
         
@@ -196,12 +196,12 @@ const ContactForm: React.FC<ContactFormProps> = ({
               type="tel"
               placeholder="Phone Number (optional)"
               className={`w-full pl-10 pr-4 py-2 rounded-lg border text-gray-900 placeholder-gray-500 focus:outline-none ${
-                errors.phone ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+                errors.phone ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.phone && (
-            <p className="mt-1 text-sm text-red-600">{errors.phone.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.phone.message}</p>
           )}
         </div>
 
@@ -211,7 +211,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
               required: 'Please select how we can help you' 
             })}
             className={`w-full px-4 py-2 rounded-lg border text-gray-900 focus:outline-none ${
-              errors.contactType ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+              errors.contactType ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
             }`}
           >
             <option value="">How can we help you?</option>
@@ -221,7 +221,7 @@ const ContactForm: React.FC<ContactFormProps> = ({
             <option value="general">General inquiry</option>
           </select>
           {errors.contactType && (
-            <p className="mt-1 text-sm text-red-600">{errors.contactType.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.contactType.message}</p>
           )}
         </div>
         
@@ -234,11 +234,11 @@ const ContactForm: React.FC<ContactFormProps> = ({
             type="text"
             placeholder="Subject"
             className={`w-full px-4 py-2 rounded-lg border text-gray-900 placeholder-gray-500 focus:outline-none ${
-              errors.subject ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+              errors.subject ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
             }`}
           />
           {errors.subject && (
-            <p className="mt-1 text-sm text-red-600">{errors.subject.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.subject.message}</p>
           )}
         </div>
         
@@ -253,19 +253,19 @@ const ContactForm: React.FC<ContactFormProps> = ({
               placeholder="Your message"
               rows={4}
               className={`w-full pl-10 pr-4 py-2 rounded-lg border text-gray-900 placeholder-gray-500 focus:outline-none resize-none ${
-                errors.message ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500'
+                errors.message ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-300 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.message && (
-            <p className="mt-1 text-sm text-red-600">{errors.message.message}</p>
+            <p className="mt-1 text-sm text-brand-teal">{errors.message.message}</p>
           )}
         </div>
         
         <button 
           type="submit"
           disabled={isSubmitting}
-          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center disabled:cursor-not-allowed"
+          className="w-full bg-brand-teal hover:bg-brand-plum disabled:bg-brand-stone text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center disabled:cursor-not-allowed"
         >
           {isSubmitting ? (
             <>

--- a/components/ContactFormImproved.tsx
+++ b/components/ContactFormImproved.tsx
@@ -128,17 +128,17 @@ const ContactFormImproved: React.FC<ContactFormImprovedProps> = ({
       <CardContent>
         {/* Success Message */}
         {submitStatus === 'success' && (
-          <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center">
-            <CheckCircle className="h-5 w-5 text-green-500 mr-3" />
-            <span className="text-green-800">Thank you! Your message has been sent. We'll get back to you soon.</span>
+          <div className="mb-6 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg flex items-center">
+            <CheckCircle className="h-5 w-5 text-brand-teal mr-3" />
+            <span className="text-brand-plum">Thank you! Your message has been sent. We'll get back to you soon.</span>
           </div>
         )}
 
         {/* Error Message */}
         {submitStatus === 'error' && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center">
-            <AlertCircle className="h-5 w-5 text-red-500 mr-3" />
-            <span className="text-red-800">{errorMessage}</span>
+          <div className="mb-6 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg flex items-center">
+            <AlertCircle className="h-5 w-5 text-brand-teal mr-3" />
+            <span className="text-brand-plum">{errorMessage}</span>
           </div>
         )}
         

--- a/components/CustomRegistrationForm.tsx
+++ b/components/CustomRegistrationForm.tsx
@@ -157,7 +157,7 @@ const CustomRegistrationForm: React.FC<CustomRegistrationFormProps> = ({
                 onChange={handleInputChange}
                 required={field.required}
                 placeholder={field.placeholder}
-                className="w-full px-4 py-2.5 border border-gray-200 rounded-md focus:ring-1 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-400 text-sm"
+                className="w-full px-4 py-2.5 border border-gray-200 rounded-md focus:ring-1 focus:ring-brand-teal focus:border-brand-teal placeholder-gray-400 text-sm"
                 aria-label={field.label}
               />
             ))}
@@ -172,7 +172,7 @@ const CustomRegistrationForm: React.FC<CustomRegistrationFormProps> = ({
               onChange={handleInputChange}
               required={field.required}
               placeholder={field.placeholder}
-              className="w-full px-4 py-2.5 border border-gray-200 rounded-md focus:ring-1 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-400 text-sm"
+              className="w-full px-4 py-2.5 border border-gray-200 rounded-md focus:ring-1 focus:ring-brand-teal focus:border-brand-teal placeholder-gray-400 text-sm"
               aria-label={field.label}
             />
           ))}
@@ -181,7 +181,7 @@ const CustomRegistrationForm: React.FC<CustomRegistrationFormProps> = ({
             <input
               type="checkbox"
               id="termsCheckbox"
-              className="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+              className="h-4 w-4 text-brand-teal rounded border-gray-300 focus:ring-brand-teal"
             />
             <label htmlFor="termsCheckbox" className="ml-2 text-xs text-gray-500">
               I am interested and/or affiliated with properties on this market.
@@ -191,7 +191,7 @@ const CustomRegistrationForm: React.FC<CustomRegistrationFormProps> = ({
           <button
             type="submit"
             disabled={isSubmitting}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-3 rounded-md font-medium text-sm uppercase tracking-wide mt-4"
+            className="w-full bg-brand-teal hover:bg-brand-plum disabled:bg-gray-400 text-white px-6 py-3 rounded-md font-medium text-sm uppercase tracking-wide mt-4"
           >
             {isSubmitting ? (
               <>
@@ -205,16 +205,16 @@ const CustomRegistrationForm: React.FC<CustomRegistrationFormProps> = ({
         </form>
 
         {submitStatus === 'success' && (
-          <div className="mt-4 p-4 bg-green-50 border border-green-200 rounded-lg">
-            <p className="text-green-800 text-sm">
+          <div className="mt-4 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg">
+            <p className="text-brand-plum text-sm">
               Registration successful! We'll be in touch shortly.
             </p>
           </div>
         )}
 
         {submitStatus === 'error' && (
-          <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-            <p className="text-red-800 text-sm">
+          <div className="mt-4 p-4 bg-brand-mint/40 border border-brand-mint rounded-lg">
+            <p className="text-brand-plum text-sm">
               There was an error submitting your registration. Please try again.
             </p>
           </div>

--- a/components/DigitalSignIn.tsx
+++ b/components/DigitalSignIn.tsx
@@ -20,7 +20,7 @@ const DigitalSignIn: React.FC<DigitalSignInProps> = ({
   return (
     <div className={`bg-white rounded-lg shadow-md p-6 ${className}`}>
       <div className="text-center mb-6">
-        <User className="h-12 w-12 text-blue-600 mx-auto mb-4" />
+        <User className="h-12 w-12 text-brand-teal mx-auto mb-4" />
         <h3 className="text-xl font-bold text-gray-900 mb-2">Schedule a private showing</h3>
         <p className="text-gray-600">Welcome to {propertyAddress}</p>
         <div className="flex items-center justify-center mt-2 text-sm text-gray-500">
@@ -33,7 +33,7 @@ const DigitalSignIn: React.FC<DigitalSignInProps> = ({
         Book a time with Dr. Jan Duffy for a personalized tour or consultation.
       </p>
 
-      <CalendlyPopupLink className="w-full flex items-center justify-center bg-[#0069ff] hover:bg-[#0052cc] text-white px-6 py-3 rounded-lg font-medium mb-6">
+      <CalendlyPopupLink className="w-full flex items-center justify-center bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-lg font-medium mb-6">
         <Calendar className="h-4 w-4 mr-2" />
         Schedule a private showing
       </CalendlyPopupLink>

--- a/components/DirectionsWidget.tsx
+++ b/components/DirectionsWidget.tsx
@@ -175,13 +175,13 @@ export default function DirectionsWidget({ destinations, className = '' }: Direc
                 value={origin}
                 onChange={(e) => setOrigin(e.target.value)}
                 placeholder="e.g. Las Vegas, NV or 123 Main St"
-                className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
               />
               <button
                 type="button"
                 onClick={handleUseMyLocation}
                 disabled={loading}
-                className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+                className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-brand-teal text-white text-sm font-medium hover:bg-brand-plum disabled:opacity-50"
                 title="Use my location"
               >
                 <MapPin className="h-4 w-4" />
@@ -198,7 +198,7 @@ export default function DirectionsWidget({ destinations, className = '' }: Direc
               id="directions-destination"
               value={destinationId}
               onChange={(e) => setDestinationId(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
             >
               {destinations.map((d) => (
                 <option key={d.id} value={d.id}>
@@ -218,8 +218,8 @@ export default function DirectionsWidget({ destinations, className = '' }: Direc
                   onClick={() => setTravelMode(opt.value)}
                   className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
                     travelMode === opt.value
-                      ? 'border-blue-600 bg-blue-600 text-white'
-                      : 'border-gray-300 bg-white text-gray-700 hover:border-blue-400'
+                      ? 'border-brand-teal bg-brand-teal text-white'
+                      : 'border-gray-300 bg-white text-gray-700 hover:border-brand-teal'
                   }`}
                 >
                   {opt.icon}
@@ -233,13 +233,13 @@ export default function DirectionsWidget({ destinations, className = '' }: Direc
             type="button"
             onClick={handleGetDirections}
             disabled={loading || !origin.trim()}
-            className="w-full flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-3 text-white font-semibold hover:bg-blue-700 disabled:opacity-50"
+            className="w-full flex items-center justify-center gap-2 rounded-lg bg-brand-teal px-4 py-3 text-white font-semibold hover:bg-brand-plum disabled:opacity-50"
           >
             {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Navigation className="h-5 w-5" />}
             Get directions
           </button>
 
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p className="text-sm text-brand-teal">{error}</p>}
         </div>
 
         {/* Map + results */}
@@ -249,7 +249,7 @@ export default function DirectionsWidget({ destinations, className = '' }: Direc
             {!isLoaded && (
               <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
                 <div className="text-center">
-                  <Loader2 className="h-10 w-10 animate-spin text-blue-600 mx-auto mb-2" />
+                  <Loader2 className="h-10 w-10 animate-spin text-brand-teal mx-auto mb-2" />
                   <p className="text-sm text-gray-600">Loading map...</p>
                 </div>
               </div>

--- a/components/FAQAccordion.tsx
+++ b/components/FAQAccordion.tsx
@@ -36,7 +36,7 @@ export default function FAQAccordion({ faqs, title = 'Frequently Asked Questions
                 id={`faq-question-${index}`}
               >
                 <span className="text-lg font-semibold text-gray-900">
-                  <span className="text-blue-600 mr-2">Q:</span>
+                  <span className="text-brand-teal mr-2">Q:</span>
                   {faq.question}
                 </span>
                 <span className="shrink-0 text-gray-500 text-xl" aria-hidden>
@@ -51,7 +51,7 @@ export default function FAQAccordion({ faqs, title = 'Frequently Asked Questions
               >
                 <div className="px-6 pb-4 pt-0">
                   <p className="text-gray-700 leading-relaxed border-t border-gray-100 pt-4">
-                    <span className="text-red-600 mr-2 font-semibold">A:</span>
+                    <span className="text-brand-teal mr-2 font-semibold">A:</span>
                     {faq.answer}
                   </p>
                 </div>

--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -27,11 +27,11 @@ export default function FAQSection({ faqs, title = 'Frequently Asked Questions',
             {faqs.map((faq, index) => (
               <div key={index} className="bg-white rounded-xl shadow-lg border border-gray-100 p-6 hover:shadow-xl transition-shadow">
                 <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                  <span className="text-blue-600 mr-2">Q:</span>
+                  <span className="text-brand-teal mr-2">Q:</span>
                   {faq.question}
                 </h3>
                 <p className="text-gray-700 leading-relaxed">
-                  <span className="text-red-600 mr-2 font-semibold">A:</span>
+                  <span className="text-brand-teal mr-2 font-semibold">A:</span>
                   {faq.answer}
                 </p>
               </div>

--- a/components/FeaturedOpenHouses.tsx
+++ b/components/FeaturedOpenHouses.tsx
@@ -56,7 +56,7 @@ export default function FeaturedOpenHouses() {
     <section className="py-12 sm:py-16">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-12 text-center">
-          <div className="mb-4 inline-flex items-center rounded-full bg-red-100 px-4 py-2 text-sm font-medium text-red-800">
+          <div className="mb-4 inline-flex items-center rounded-full bg-brand-mint px-4 py-2 text-sm font-medium text-brand-plum">
             <Calendar className="mr-2 h-4 w-4" />
             This Weekend Only - Don&apos;t Miss Out!
           </div>
@@ -65,7 +65,7 @@ export default function FeaturedOpenHouses() {
           </h2>
           <p className="mb-6 text-lg text-gray-600">
             {filteredHouses.length} premium Summerlin Las Vegas open houses in Summerlin West.{' '}
-            <Link href="/open-houses" className="font-semibold text-blue-600 hover:underline">
+            <Link href="/open-houses" className="font-semibold text-brand-teal hover:underline">
               See all Summerlin Las Vegas open house listings
             </Link>
             .
@@ -103,7 +103,7 @@ export default function FeaturedOpenHouses() {
                   '_blank'
                 )
               }
-              className="min-h-[44px] inline-flex items-center justify-center rounded-xl bg-blue-600 px-6 py-3 font-semibold text-white shadow-md transition-all duration-200 hover:bg-blue-700 hover:shadow-lg"
+              className="min-h-[44px] inline-flex items-center justify-center rounded-xl bg-brand-teal px-6 py-3 font-semibold text-white shadow-md transition-all duration-200 hover:bg-brand-plum hover:shadow-lg"
             >
               View All Listings
             </button>
@@ -168,17 +168,17 @@ export default function FeaturedOpenHouses() {
                   >
                     <Heart
                       className={`h-5 w-5 ${
-                        favorites.includes(house.id) ? 'fill-current text-red-500' : 'text-gray-600'
+                        favorites.includes(house.id) ? 'fill-current text-brand-teal' : 'text-gray-600'
                       }`}
                     />
                   </button>
                   <div className="absolute bottom-3 left-3">
-                    <span className="rounded bg-blue-600 px-2 py-1 text-sm font-medium text-white">
+                    <span className="rounded bg-brand-teal px-2 py-1 text-sm font-medium text-white">
                       {house.openHouseTime}
                     </span>
                   </div>
                   <div className="absolute left-3 top-3">
-                    <span className="rounded bg-red-600 px-2 py-1 text-sm font-medium text-white">
+                    <span className="rounded bg-brand-teal px-2 py-1 text-sm font-medium text-white">
                       New This Weekend!
                     </span>
                   </div>
@@ -200,12 +200,12 @@ export default function FeaturedOpenHouses() {
                     (NEIGHBORHOOD_URL_MAP[house.neighborhood] ? (
                       <Link
                         href={NEIGHBORHOOD_URL_MAP[house.neighborhood]!}
-                        className="mb-3 inline-block text-sm font-medium text-blue-600 hover:text-blue-800"
+                        className="mb-3 inline-block text-sm font-medium text-brand-teal hover:text-brand-plum"
                       >
                         {house.neighborhood}
                       </Link>
                     ) : (
-                      <p className="mb-3 text-sm font-medium text-blue-600">{house.neighborhood}</p>
+                      <p className="mb-3 text-sm font-medium text-brand-teal">{house.neighborhood}</p>
                     ))}
 
                   <div className="mb-3 flex justify-between text-sm text-gray-600">
@@ -234,11 +234,11 @@ export default function FeaturedOpenHouses() {
                     <button
                       type="button"
                       onClick={() => setDetailListing(house)}
-                      className="w-full rounded border border-blue-600 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50"
+                      className="w-full rounded border border-brand-teal px-3 py-2 text-sm font-medium text-brand-teal hover:bg-brand-mint/40"
                     >
                       View details
                     </button>
-                    <CalendlyPopupLink className="flex-1 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 text-center block">
+                    <CalendlyPopupLink className="flex-1 rounded bg-brand-teal px-3 py-2 text-sm font-medium text-white hover:bg-brand-plum text-center block">
                       Schedule a private showing
                     </CalendlyPopupLink>
                     <button

--- a/components/FollowupBossIntegration.tsx
+++ b/components/FollowupBossIntegration.tsx
@@ -139,7 +139,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
               onChange={handleInputChange}
               required
               autoComplete="name"
-              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-brand-teal focus:outline-none"
             />
           </div>
         </div>
@@ -155,7 +155,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
               onChange={handleInputChange}
               required
               autoComplete="email"
-              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-brand-teal focus:outline-none"
             />
           </div>
         </div>
@@ -171,7 +171,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
                 value={formData.phone}
                 onChange={handleInputChange}
                 autoComplete="tel"
-                className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+                className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-brand-teal focus:outline-none"
               />
             </div>
           </div>
@@ -187,7 +187,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
               required
               aria-label="Select interested neighborhood"
               title="Select interested neighborhood"
-              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white focus:border-blue-500 focus:outline-none"
+              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white focus:border-brand-teal focus:outline-none"
             >
               <option value="">Select Neighborhood</option>
               {neighborhoods.map((neighborhood) => (
@@ -207,7 +207,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
               value={formData.message}
               onChange={handleInputChange}
               rows={3}
-              className="w-full px-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+              className="w-full px-4 py-2 rounded-lg bg-gray-700 border border-gray-600 text-white placeholder-gray-400 focus:border-brand-teal focus:outline-none"
             />
           </div>
         )}
@@ -215,7 +215,7 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
         <button
           type="submit"
           disabled={isSubmitting}
-          className="w-full bg-red-600 hover:bg-red-700 disabled:bg-gray-600 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
+          className="w-full bg-brand-teal hover:bg-brand-plum disabled:bg-gray-600 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
         >
           {isSubmitting ? (
             <>
@@ -231,13 +231,13 @@ const FollowupBossIntegration: React.FC<FollowupBossIntegrationProps> = ({
         </button>
 
         {submitStatus === 'success' && (
-          <div className="text-green-400 text-sm text-center" role="status">
+          <div className="text-brand-mint text-sm text-center" role="status">
             Thank you! We&apos;ll be in touch with Summerlin West market updates.
           </div>
         )}
 
         {submitStatus === 'error' && (
-          <div className="text-red-400 text-sm text-center" role="alert">
+          <div className="text-brand-plum text-sm text-center" role="alert">
             Something went wrong. Please try again or contact us directly.
           </div>
         )}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
   const [logoError, setLogoError] = useState(false)
 
   return (
-    <footer className="bg-gray-800 text-gray-300 py-10 border-t-4 border-blue-600" role="contentinfo">
+    <footer className="bg-brand-plum text-gray-200 py-10 border-t-4 border-brand-teal" role="contentinfo">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Office / Search Listings – first position on every page */}
@@ -32,17 +32,17 @@ export default function Footer() {
               <li>
                 <ExternalLink
                   href="https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA=="
-                  className="text-blue-400 hover:text-blue-300 font-medium transition-colors"
+                  className="text-brand-mint hover:text-white font-medium transition-colors"
                 >
                   Search Listings
                 </ExternalLink>
               </li>
               <li className="flex items-center gap-2">
-                <Phone className="h-4 w-4 shrink-0 text-red-500" aria-hidden />
+                <Phone className="h-4 w-4 shrink-0 text-brand-mint" aria-hidden />
                 <a href={BUSINESS.phoneLink} className="min-h-[44px] inline-flex items-center hover:text-white">{BUSINESS.phone}</a>
               </li>
               <li className="flex items-start gap-2">
-                <MapPin className="h-4 w-4 shrink-0 text-red-500 mt-0.5" aria-hidden />
+                <MapPin className="h-4 w-4 shrink-0 text-brand-mint mt-0.5" aria-hidden />
                 <span>
                   {BUSINESS.address}
                   <span className="block text-gray-400 mt-2 text-xs leading-relaxed">
@@ -53,7 +53,7 @@ export default function Footer() {
               <li>
                 <ExternalLink
                   href={FACEBOOK_PAGE_URL}
-                  className="text-blue-400 hover:text-blue-300 transition-colors"
+                  className="text-brand-mint hover:text-white transition-colors"
                 >
                   Facebook
                 </ExternalLink>
@@ -63,7 +63,7 @@ export default function Footer() {
               <li><Link href="/book-tour" className="hover:text-white transition-colors">Schedule a private showing</Link></li>
               <li><Link href="/schedule-consultation" className="hover:text-white transition-colors">Schedule a free consultation</Link></li>
               <li>
-                <CalendlyPopupLink className="inline-flex min-h-[44px] items-center justify-center gap-2 mt-2 px-4 py-2 rounded-lg bg-[#0069ff] text-white hover:bg-[#0052cc] font-semibold text-sm transition-colors">
+                <CalendlyPopupLink className="inline-flex min-h-[44px] items-center justify-center gap-2 mt-2 px-4 py-2 rounded-lg bg-brand-teal text-white hover:bg-brand-mint hover:text-brand-plum font-semibold text-sm transition-colors">
                   <Calendar className="h-4 w-4" aria-hidden />
                   Schedule a private showing
                 </CalendlyPopupLink>
@@ -122,7 +122,7 @@ export default function Footer() {
                   unoptimized
                 />
               ) : (
-                <Home className="h-6 w-6 text-red-500 shrink-0" aria-hidden />
+                <Home className="h-6 w-6 text-brand-mint shrink-0" aria-hidden />
               )}
               <span className="font-bold text-white">{SITE_NAME}</span>
             </Link>

--- a/components/GoogleBusinessProfile.tsx
+++ b/components/GoogleBusinessProfile.tsx
@@ -100,7 +100,7 @@ export default function GoogleBusinessProfile({
       {/* NAP Information */}
       <div className="space-y-4 mb-6">
         <div className="flex items-start">
-          <MapPin className="h-5 w-5 text-blue-600 mr-3 mt-1 flex-shrink-0" />
+          <MapPin className="h-5 w-5 text-brand-teal mr-3 mt-1 flex-shrink-0" />
           <div>
             <p className="font-semibold text-gray-900">{BUSINESS_INFO.name}</p>
             <p className="text-gray-700">{BUSINESS_INFO.address.street}</p>
@@ -114,10 +114,10 @@ export default function GoogleBusinessProfile({
         </div>
 
         <div className="flex items-center">
-          <Phone className="h-5 w-5 text-blue-600 mr-3 flex-shrink-0" />
+          <Phone className="h-5 w-5 text-brand-teal mr-3 flex-shrink-0" />
           <a 
             href={BUSINESS_INFO.phoneLink}
-            className="text-blue-600 hover:text-blue-800 font-semibold text-lg"
+            className="text-brand-teal hover:text-brand-plum font-semibold text-lg"
             aria-label={`Call ${BUSINESS_INFO.phone}`}
           >
             {BUSINESS_INFO.phone}
@@ -125,10 +125,10 @@ export default function GoogleBusinessProfile({
         </div>
 
         <div className="flex items-center">
-          <Mail className="h-5 w-5 text-blue-600 mr-3 flex-shrink-0" />
+          <Mail className="h-5 w-5 text-brand-teal mr-3 flex-shrink-0" />
           <a 
             href={`mailto:${BUSINESS_INFO.email}`}
-            className="text-blue-600 hover:text-blue-800"
+            className="text-brand-teal hover:text-brand-plum"
             aria-label={`Email ${BUSINESS_INFO.email}`}
           >
             {BUSINESS_INFO.email}
@@ -136,7 +136,7 @@ export default function GoogleBusinessProfile({
         </div>
 
         <div className="flex items-start">
-          <Clock className="h-5 w-5 text-blue-600 mr-3 mt-1 flex-shrink-0" />
+          <Clock className="h-5 w-5 text-brand-teal mr-3 mt-1 flex-shrink-0" />
           <div className="text-gray-700">
             <p className="font-semibold mb-1">Business Hours</p>
             <p>{BUSINESS_INFO.hours.weekdays}</p>
@@ -186,7 +186,7 @@ export default function GoogleBusinessProfile({
       </div>
       <p className="text-sm text-gray-600 text-center mb-4">
         Want to leave a review?{' '}
-        <Link href="/review-us" className="text-blue-600 hover:underline font-medium">
+        <Link href="/review-us" className="text-brand-teal hover:underline font-medium">
           Review us on Google
         </Link>
       </p>
@@ -203,7 +203,7 @@ export default function GoogleBusinessProfile({
           <p className="text-sm text-gray-600 mt-2 text-center">
             <ExternalLink
               href={BUSINESS_INFO.googleBusinessUrl}
-              className="text-blue-600 hover:text-blue-800"
+              className="text-brand-teal hover:text-brand-plum"
               ariaLabel="View on Google Maps"
             >
               View on Google Maps
@@ -224,7 +224,7 @@ export default function GoogleBusinessProfile({
           </p>
           <ExternalLink
             href={BUSINESS_INFO.reviewsUrl}
-            className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium"
+            className="inline-flex items-center text-brand-teal hover:text-brand-plum font-medium"
             ariaLabel="View all reviews on Google"
           >
             View All Reviews on Google

--- a/components/HyperLocalNeighborhoodPage.tsx
+++ b/components/HyperLocalNeighborhoodPage.tsx
@@ -73,7 +73,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             <p className="text-xl text-gray-200 mb-8">{description}</p>
             <button
               onClick={handleRealScoutClick}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200"
+              className="bg-brand-teal hover:bg-brand-plum text-white px-8 py-4 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200"
             >
               View Available Homes
             </button>
@@ -88,7 +88,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             <button
               onClick={() => setActiveTab('overview')}
               className={`px-6 py-4 font-medium ${
-                activeTab === 'overview' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-600'
+                activeTab === 'overview' ? 'text-brand-teal border-b-2 border-brand-teal' : 'text-gray-600'
               }`}
             >
               Overview
@@ -96,7 +96,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             <button
               onClick={() => setActiveTab('market')}
               className={`px-6 py-4 font-medium ${
-                activeTab === 'market' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-600'
+                activeTab === 'market' ? 'text-brand-teal border-b-2 border-brand-teal' : 'text-gray-600'
               }`}
             >
               Market Stats
@@ -104,7 +104,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             <button
               onClick={() => setActiveTab('schools')}
               className={`px-6 py-4 font-medium ${
-                activeTab === 'schools' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-600'
+                activeTab === 'schools' ? 'text-brand-teal border-b-2 border-brand-teal' : 'text-gray-600'
               }`}
             >
               Schools
@@ -112,7 +112,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             <button
               onClick={() => setActiveTab('amenities')}
               className={`px-6 py-4 font-medium ${
-                activeTab === 'amenities' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-600'
+                activeTab === 'amenities' ? 'text-brand-teal border-b-2 border-brand-teal' : 'text-gray-600'
               }`}
             >
               Amenities
@@ -137,19 +137,19 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                   <h3 className="text-xl font-bold text-gray-900 mb-4">Current Market Snapshot</h3>
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                     <div className="text-center">
-                      <div className="text-2xl font-bold text-blue-600">{marketStats.medianPrice}</div>
+                      <div className="text-2xl font-bold text-brand-teal">{marketStats.medianPrice}</div>
                       <div className="text-sm text-gray-600">Median Price</div>
                     </div>
                     <div className="text-center">
-                      <div className="text-2xl font-bold text-blue-600">{marketStats.daysOnMarket}</div>
+                      <div className="text-2xl font-bold text-brand-teal">{marketStats.daysOnMarket}</div>
                       <div className="text-sm text-gray-600">Days on Market</div>
                     </div>
                     <div className="text-center">
-                      <div className="text-2xl font-bold text-blue-600">{marketStats.activeListings}</div>
+                      <div className="text-2xl font-bold text-brand-teal">{marketStats.activeListings}</div>
                       <div className="text-sm text-gray-600">Active Listings</div>
                     </div>
                     <div className="text-center">
-                      <div className="text-2xl font-bold text-blue-600">{marketStats.pricePerSqFt}</div>
+                      <div className="text-2xl font-bold text-brand-teal">{marketStats.pricePerSqFt}</div>
                       <div className="text-sm text-gray-600">Price/Sq.Ft</div>
                     </div>
                   </div>
@@ -167,7 +167,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                       <div className="text-sm text-gray-600">Median Home Price</div>
                       <div className="text-xl font-bold text-gray-900">{marketStats.medianPrice}</div>
                     </div>
-                    <div className="text-sm text-green-600">
+                    <div className="text-sm text-brand-teal">
                       {marketStats.monthlyChange} from last month
                     </div>
                   </div>
@@ -177,7 +177,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                       <div className="text-sm text-gray-600">Average Days on Market</div>
                       <div className="text-xl font-bold text-gray-900">{marketStats.daysOnMarket} days</div>
                     </div>
-                    <Clock className="h-6 w-6 text-blue-600" />
+                    <Clock className="h-6 w-6 text-brand-teal" />
                   </div>
                   
                   <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
@@ -185,7 +185,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                       <div className="text-sm text-gray-600">Active Listings</div>
                       <div className="text-xl font-bold text-gray-900">{marketStats.activeListings}</div>
                     </div>
-                    <Home className="h-6 w-6 text-blue-600" />
+                    <Home className="h-6 w-6 text-brand-teal" />
                   </div>
                   
                   <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
@@ -193,7 +193,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                       <div className="text-sm text-gray-600">Price per Square Foot</div>
                       <div className="text-xl font-bold text-gray-900">{marketStats.pricePerSqFt}</div>
                     </div>
-                    <ChartBar className="h-6 w-6 text-blue-600" />
+                    <ChartBar className="h-6 w-6 text-brand-teal" />
                   </div>
                 </div>
               </div>
@@ -205,7 +205,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                 <div className="space-y-4">
                   {schools.map((school, index) => (
                     <div key={index} className="flex items-start p-4 bg-gray-50 rounded-lg">
-                      <School className="h-6 w-6 text-blue-600 mt-1 mr-4" />
+                      <School className="h-6 w-6 text-brand-teal mt-1 mr-4" />
                       <div>
                         <div className="font-medium text-gray-900">{school.name}</div>
                         <div className="text-sm text-gray-600">{school.type}</div>
@@ -225,9 +225,9 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
                   {amenities.map((amenity, index) => (
                     <div key={index} className="flex items-start p-4 bg-gray-50 rounded-lg">
                       {amenity.type === 'park' ? (
-                        <Leaf className="h-6 w-6 text-green-600 mt-1 mr-4" />
+                        <Leaf className="h-6 w-6 text-brand-teal mt-1 mr-4" />
                       ) : (
-                        <MapPin className="h-6 w-6 text-blue-600 mt-1 mr-4" />
+                        <MapPin className="h-6 w-6 text-brand-teal mt-1 mr-4" />
                       )}
                       <div>
                         <div className="font-medium text-gray-900">{amenity.name}</div>
@@ -259,19 +259,19 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
               <h3 className="text-xl font-bold text-gray-900 mb-4">Quick Facts</h3>
               <div className="space-y-3">
                 <div className="flex items-center">
-                  <Car className="h-5 w-5 text-blue-600 mr-3" />
+                  <Car className="h-5 w-5 text-brand-teal mr-3" />
                   <span className="text-gray-600">15 minutes to Downtown</span>
                 </div>
                 <div className="flex items-center">
-                  <School className="h-5 w-5 text-blue-600 mr-3" />
+                  <School className="h-5 w-5 text-brand-teal mr-3" />
                   <span className="text-gray-600">Top-rated schools nearby</span>
                 </div>
                 <div className="flex items-center">
-                  <Leaf className="h-5 w-5 text-blue-600 mr-3" />
+                  <Leaf className="h-5 w-5 text-brand-teal mr-3" />
                   <span className="text-gray-600">Multiple parks and trails</span>
                 </div>
                 <div className="flex items-center">
-                  <Home className="h-5 w-5 text-blue-600 mr-3" />
+                  <Home className="h-5 w-5 text-brand-teal mr-3" />
                   <span className="text-gray-600">Gated communities available</span>
                 </div>
               </div>
@@ -280,7 +280,7 @@ const HyperLocalNeighborhoodPage: React.FC<HyperLocalNeighborhoodPageProps> = ({
             {/* CTA Button */}
             <button
               onClick={handleRealScoutClick}
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-bold text-lg shadow-lg"
+              className="w-full bg-brand-teal hover:bg-brand-plum text-white px-6 py-3 rounded-lg font-bold text-lg shadow-lg"
             >
               View All {name} Listings
             </button>

--- a/components/InteractiveMap.tsx
+++ b/components/InteractiveMap.tsx
@@ -103,7 +103,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
         icon: {
           url: 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(`
             <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="16" cy="16" r="12" fill="#3B82F6" stroke="white" stroke-width="2"/>
+              <circle cx="16" cy="16" r="12" fill="#6399a3" stroke="white" stroke-width="2"/>
               <path d="M16 8l-6 6v10h12V14l-6-6z" fill="white"/>
             </svg>
           `),
@@ -118,13 +118,13 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
           <div class="p-4 max-w-xs">
             <div class="font-bold text-lg text-gray-900">${property.price}</div>
             <div class="text-sm text-gray-600 mb-2">${property.address}</div>
-            <div class="text-sm text-blue-600 font-medium mb-2">${property.neighborhood}</div>
+            <div class="text-sm text-brand-teal font-medium mb-2">${property.neighborhood}</div>
             <div class="flex justify-between text-sm text-gray-600 mb-2">
               <span>${property.beds} beds</span>
               <span>${property.baths} baths</span>
               <span>${property.sqft} sqft</span>
             </div>
-            <div class="bg-blue-100 text-blue-800 px-2 py-1 rounded text-xs font-medium">
+            <div class="bg-brand-mint text-brand-plum px-2 py-1 rounded text-xs font-medium">
               ${property.openHouseTime}
             </div>
           </div>
@@ -177,7 +177,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
               key={property.id}
               className={`p-3 rounded-lg border cursor-pointer transition-colors ${
                 selectedProperty?.id === property.id
-                  ? 'border-blue-500 bg-blue-50'
+                  ? 'border-brand-teal bg-brand-mint/40'
                   : 'border-gray-200 hover:border-gray-300'
               }`}
               onClick={() => {
@@ -192,16 +192,16 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
             >
               <div className="flex justify-between items-start mb-1">
                 <div className="font-bold text-gray-900">{property.price}</div>
-                <Clock className="h-4 w-4 text-blue-600" />
+                <Clock className="h-4 w-4 text-brand-teal" />
               </div>
               <div className="text-sm text-gray-600 mb-1">{property.address}</div>
-              <div className="text-xs text-blue-600 font-medium mb-2">{property.neighborhood}</div>
+              <div className="text-xs text-brand-teal font-medium mb-2">{property.neighborhood}</div>
               <div className="flex justify-between text-xs text-gray-500">
                 <span>{property.beds} beds</span>
                 <span>{property.baths} baths</span>
                 <span>{property.sqft} sqft</span>
               </div>
-              <div className="text-xs text-blue-600 font-medium mt-1">
+              <div className="text-xs text-brand-teal font-medium mt-1">
                 {property.openHouseTime}
               </div>
             </div>
@@ -211,7 +211,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
           <div className="text-center mt-3">
             <button
               onClick={() => window.open('https://drjanduffy.realscout.com/homesearch/shared-searches/U2hhcmVhYmxlU2VhcmNoTGluay0xMDkzMA==', '_blank')}
-              className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              className="text-sm text-brand-teal hover:text-brand-plum font-medium"
             >
               View all {properties.length} properties →
             </button>
@@ -223,7 +223,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = ({
       {!isMapLoaded && (
         <div className="absolute inset-0 bg-gray-100 rounded-lg flex items-center justify-center">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-2"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-teal mx-auto mb-2"></div>
             <div className="text-sm text-gray-600">Loading map...</div>
           </div>
         </div>

--- a/components/ListingDetailModal.tsx
+++ b/components/ListingDetailModal.tsx
@@ -61,7 +61,7 @@ export function ListingDetailModal({
               {listing.neighborhood && NEIGHBORHOOD_URL_MAP[listing.neighborhood] ? (
                 <Link
                   href={NEIGHBORHOOD_URL_MAP[listing.neighborhood]!}
-                  className="font-medium text-blue-600 hover:text-blue-800"
+                  className="font-medium text-brand-teal hover:text-brand-plum"
                 >
                   {listing.neighborhood}
                 </Link>
@@ -123,7 +123,7 @@ export function ListingDetailModal({
                 <button
                   type="button"
                   onClick={handleTakeVirtualTour}
-                  className="mt-2 w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
+                  className="mt-2 w-full rounded-lg bg-brand-teal px-4 py-2 font-medium text-white hover:bg-brand-plum"
                 >
                   Take Virtual Tour (fullscreen)
                 </button>
@@ -146,7 +146,7 @@ export function ListingDetailModal({
               <button
                 type="button"
                 onClick={handleTakeVirtualTour}
-                className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                className="flex-1 rounded-lg bg-brand-teal px-4 py-2 text-sm font-medium text-white hover:bg-brand-plum disabled:opacity-50"
                 disabled={!listing.virtualTourUrl}
               >
                 Take Virtual Tour

--- a/components/NeighborhoodPage.tsx
+++ b/components/NeighborhoodPage.tsx
@@ -29,7 +29,7 @@ const NeighborhoodPage: React.FC<NeighborhoodPageProps> = ({ neighborhood }) => 
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative h-96 bg-gradient-to-r from-blue-600 to-red-600">
+      <section className="relative h-96 bg-gradient-to-r from-brand-teal to-brand-plum">
         <div className="absolute inset-0 bg-black/40"></div>
         <div className="relative h-full flex items-center justify-center">
           <div className="text-center text-white">
@@ -55,7 +55,7 @@ const NeighborhoodPage: React.FC<NeighborhoodPageProps> = ({ neighborhood }) => 
                   onClick={() => setActiveTab(tab.id)}
                   className={`flex items-center space-x-2 py-4 px-2 border-b-2 font-medium text-sm ${
                     activeTab === tab.id
-                      ? 'border-blue-600 text-blue-600'
+                      ? 'border-brand-teal text-brand-teal'
                       : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                   }`}
                 >
@@ -144,10 +144,10 @@ const NeighborhoodPage: React.FC<NeighborhoodPageProps> = ({ neighborhood }) => 
                     <div className="bg-white p-6 rounded-lg shadow-sm border">
                       <div className="flex items-center justify-between mb-4">
                         <h3 className="text-xl font-semibold text-gray-900">This Weekend's Open Houses</h3>
-                        <Clock className="h-5 w-5 text-blue-600" />
+                        <Clock className="h-5 w-5 text-brand-teal" />
                       </div>
                       <p className="text-gray-600 mb-4">Discover current open houses in {neighborhood.name}.</p>
-                      <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg font-medium">
+                      <button className="bg-brand-teal hover:bg-brand-plum text-white px-6 py-2 rounded-lg font-medium">
                         View All Open Houses
                       </button>
                     </div>
@@ -165,25 +165,25 @@ const NeighborhoodPage: React.FC<NeighborhoodPageProps> = ({ neighborhood }) => 
                   <h3 className="text-lg font-semibold text-gray-900 mb-4">Contact Dr. Jan Duffy</h3>
                   <div className="space-y-4">
                                          <div className="flex items-center">
-                       <Phone className="h-4 w-4 text-blue-600 mr-3" />
+                       <Phone className="h-4 w-4 text-brand-teal mr-3" />
                        <a 
                          href={`tel:${GBP.phoneE164}`}
-                         className="text-gray-600 hover:text-blue-600 transition-colors cursor-pointer"
+                         className="text-gray-600 hover:text-brand-plum transition-colors cursor-pointer"
                          title={`Call ${GBP.phone}`}
                        >
                          {GBP.phone}
                        </a>
                      </div>
                     <div className="flex items-center">
-                      <Mail className="h-4 w-4 text-blue-600 mr-3" />
+                      <Mail className="h-4 w-4 text-brand-teal mr-3" />
                       <span className="text-gray-600">jan@summerlinexpert.com</span>
                     </div>
                     <div className="flex items-center">
-                      <Award className="h-4 w-4 text-blue-600 mr-3" />
+                      <Award className="h-4 w-4 text-brand-teal mr-3" />
                       <span className="text-gray-600">Certified Luxury Specialist</span>
                     </div>
                   </div>
-                  <button className="w-full bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg font-medium mt-4">
+                  <button className="w-full bg-brand-teal hover:bg-brand-plum text-white px-4 py-2 rounded-lg font-medium mt-4">
                     Schedule a private showing
                   </button>
                 </div>

--- a/components/OfflineCapability.tsx
+++ b/components/OfflineCapability.tsx
@@ -161,9 +161,9 @@ const OfflineCapability: React.FC = () => {
       <div className="text-center mb-6">
         <div className="flex justify-center mb-4">
           {isOnline ? (
-            <Wifi className="h-12 w-12 text-green-600" />
+            <Wifi className="h-12 w-12 text-brand-teal" />
           ) : (
-            <WifiOff className="h-12 w-12 text-red-600" />
+            <WifiOff className="h-12 w-12 text-brand-teal" />
           )}
         </div>
         <h3 className="text-xl font-bold text-gray-900 mb-2">Offline Capability</h3>
@@ -175,11 +175,11 @@ const OfflineCapability: React.FC = () => {
       <div className="space-y-4 mb-6">
         <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
           <div className="flex items-center">
-            <Database className="h-5 w-5 text-blue-600 mr-3" />
+            <Database className="h-5 w-5 text-brand-teal mr-3" />
             <span className="text-gray-700">Service Worker</span>
           </div>
           <span className={`px-2 py-1 rounded text-xs font-medium ${
-            isServiceWorkerRegistered ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+            isServiceWorkerRegistered ? 'bg-brand-mint text-brand-plum' : 'bg-gray-100 text-gray-800'
           }`}>
             {isServiceWorkerRegistered ? 'Installed' : 'Not Installed'}
           </span>
@@ -187,21 +187,21 @@ const OfflineCapability: React.FC = () => {
 
         <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
           <div className="flex items-center">
-            <Smartphone className="h-5 w-5 text-blue-600 mr-3" />
+            <Smartphone className="h-5 w-5 text-brand-teal mr-3" />
             <span className="text-gray-700">Cached Data</span>
           </div>
-          <span className="px-2 py-1 rounded text-xs font-medium bg-blue-100 text-blue-800">
+          <span className="px-2 py-1 rounded text-xs font-medium bg-brand-mint text-brand-plum">
             {cachedData.length} items
           </span>
         </div>
 
         <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
           <div className="flex items-center">
-            <Download className="h-5 w-5 text-blue-600 mr-3" />
+            <Download className="h-5 w-5 text-brand-teal mr-3" />
             <span className="text-gray-700">Browser Support</span>
           </div>
           <span className={`px-2 py-1 rounded text-xs font-medium ${
-            isServiceWorkerSupported ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+            isServiceWorkerSupported ? 'bg-brand-mint text-brand-plum' : 'bg-brand-mint text-brand-plum'
           }`}>
             {isServiceWorkerSupported ? 'Supported' : 'Not Supported'}
           </span>
@@ -213,7 +213,7 @@ const OfflineCapability: React.FC = () => {
           <button
             onClick={registerServiceWorker}
             disabled={isInstalling}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-4 py-3 rounded-lg font-medium flex items-center justify-center"
+            className="w-full bg-brand-teal hover:bg-brand-plum disabled:bg-gray-400 text-white px-4 py-3 rounded-lg font-medium flex items-center justify-center"
           >
             {isInstalling ? (
               <>
@@ -232,7 +232,7 @@ const OfflineCapability: React.FC = () => {
         {isServiceWorkerRegistered && (
           <button
             onClick={clearCache}
-            className="w-full bg-red-600 hover:bg-red-700 text-white px-4 py-3 rounded-lg font-medium"
+            className="w-full bg-brand-teal hover:bg-brand-plum text-white px-4 py-3 rounded-lg font-medium"
           >
             Clear Cache & Uninstall
           </button>

--- a/components/OpenHouseGuideForm.tsx
+++ b/components/OpenHouseGuideForm.tsx
@@ -46,7 +46,7 @@ export default function OpenHouseGuideForm() {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
         <label htmlFor="guide-email" className="block text-sm font-medium text-gray-700 mb-1">
-          Email <span className="text-red-600">*</span>
+          Email <span className="text-brand-teal">*</span>
         </label>
         <input
           id="guide-email"
@@ -54,7 +54,7 @@ export default function OpenHouseGuideForm() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           placeholder="you@example.com"
           disabled={status === 'submitting'}
         />
@@ -68,21 +68,21 @@ export default function OpenHouseGuideForm() {
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           placeholder="Your name"
           disabled={status === 'submitting'}
         />
       </div>
       {status === 'success' && (
-        <p className="text-green-700 font-medium">Thanks! We&apos;ll send your guide shortly.</p>
+        <p className="text-brand-plum font-medium">Thanks! We&apos;ll send your guide shortly.</p>
       )}
       {status === 'error' && (
-        <p className="text-red-600 font-medium">{errorMessage || 'Something went wrong. Please try again.'}</p>
+        <p className="text-brand-teal font-medium">{errorMessage || 'Something went wrong. Please try again.'}</p>
       )}
       <button
         type="submit"
         disabled={status === 'submitting'}
-        className="w-full rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        className="w-full rounded-lg bg-brand-teal px-4 py-3 font-semibold text-white hover:bg-brand-plum disabled:opacity-50 transition-colors"
       >
         {status === 'submitting' ? 'Sending…' : 'Get My Free Guide'}
       </button>

--- a/components/OpenHouseSignInForm.tsx
+++ b/components/OpenHouseSignInForm.tsx
@@ -108,7 +108,7 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
         <div className="flex flex-col gap-3">
           <a
             href="/open-houses"
-            className="block w-full text-center rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-3 transition-colors"
+            className="block w-full text-center rounded-lg bg-brand-teal hover:bg-brand-plum text-white font-semibold px-4 py-3 transition-colors"
           >
             Browse more open houses
           </a>
@@ -117,7 +117,7 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           </CalendlyPopupLink>
           <a
             href="/open-houses"
-            className="block w-full text-center text-blue-600 font-medium hover:underline"
+            className="block w-full text-center text-brand-teal font-medium hover:underline"
           >
             View open houses
           </a>
@@ -130,7 +130,7 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
     <form onSubmit={handleSubmit} className="space-y-5">
       <div>
         <label htmlFor="oh-fullName" className="block text-sm font-medium text-gray-700 mb-1">
-          Full name <span className="text-red-600">*</span>
+          Full name <span className="text-brand-teal">*</span>
         </label>
         <input
           id="oh-fullName"
@@ -138,15 +138,15 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           required
           value={fullName}
           onChange={(e) => setFullName(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           placeholder="Jane Smith"
           disabled={status === 'submitting'}
         />
-        {errors.fullName && <p className="mt-1 text-sm text-red-600">{errors.fullName}</p>}
+        {errors.fullName && <p className="mt-1 text-sm text-brand-teal">{errors.fullName}</p>}
       </div>
       <div>
         <label htmlFor="oh-email" className="block text-sm font-medium text-gray-700 mb-1">
-          Email <span className="text-red-600">*</span>
+          Email <span className="text-brand-teal">*</span>
         </label>
         <input
           id="oh-email"
@@ -154,15 +154,15 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           placeholder="jane@example.com"
           disabled={status === 'submitting'}
         />
-        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+        {errors.email && <p className="mt-1 text-sm text-brand-teal">{errors.email}</p>}
       </div>
       <div>
         <label htmlFor="oh-phone" className="block text-sm font-medium text-gray-700 mb-1">
-          Phone <span className="text-red-600">*</span>
+          Phone <span className="text-brand-teal">*</span>
         </label>
         <input
           id="oh-phone"
@@ -170,11 +170,11 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           required
           value={phone}
           onChange={handlePhoneChange}
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           placeholder="(702) 555-1234"
           disabled={status === 'submitting'}
         />
-        {errors.phone && <p className="mt-1 text-sm text-red-600">{errors.phone}</p>}
+        {errors.phone && <p className="mt-1 text-sm text-brand-teal">{errors.phone}</p>}
       </div>
       <div>
         <p className="block text-sm font-medium text-gray-700 mb-2">Are you working with an agent?</p>
@@ -208,21 +208,21 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
             value={agentName}
             onChange={(e) => setAgentName(e.target.value)}
             placeholder="Agent name (optional)"
-            className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
             disabled={status === 'submitting'}
           />
         )}
       </div>
       <div>
         <label htmlFor="oh-hearAbout" className="block text-sm font-medium text-gray-700 mb-1">
-          How did you hear about this open house? <span className="text-red-600">*</span>
+          How did you hear about this open house? <span className="text-brand-teal">*</span>
         </label>
         <select
           id="oh-hearAbout"
           required
           value={hearAboutSource}
           onChange={(e) => setHearAboutSource(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           disabled={status === 'submitting'}
         >
           <option value="">Select...</option>
@@ -233,12 +233,12 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           ))}
         </select>
         {errors.hearAboutSource && (
-          <p className="mt-1 text-sm text-red-600">{errors.hearAboutSource}</p>
+          <p className="mt-1 text-sm text-brand-teal">{errors.hearAboutSource}</p>
         )}
       </div>
       <div>
         <p className="block text-sm font-medium text-gray-700 mb-2">
-          Are you pre-approved for a mortgage? <span className="text-red-600">*</span>
+          Are you pre-approved for a mortgage? <span className="text-brand-teal">*</span>
         </p>
         <div className="flex flex-wrap gap-3">
           {PRE_APPROVED_OPTIONS.map((opt) => (
@@ -256,18 +256,18 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
             </label>
           ))}
         </div>
-        {errors.preApproved && <p className="mt-1 text-sm text-red-600">{errors.preApproved}</p>}
+        {errors.preApproved && <p className="mt-1 text-sm text-brand-teal">{errors.preApproved}</p>}
       </div>
       <div>
         <label htmlFor="oh-timeline" className="block text-sm font-medium text-gray-700 mb-1">
-          What is your timeline to purchase? <span className="text-red-600">*</span>
+          What is your timeline to purchase? <span className="text-brand-teal">*</span>
         </label>
         <select
           id="oh-timeline"
           required
           value={purchaseTimeline}
           onChange={(e) => setPurchaseTimeline(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-brand-teal focus:ring-1 focus:ring-brand-teal"
           disabled={status === 'submitting'}
         >
           <option value="">Select...</option>
@@ -278,7 +278,7 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
           ))}
         </select>
         {errors.purchaseTimeline && (
-          <p className="mt-1 text-sm text-red-600">{errors.purchaseTimeline}</p>
+          <p className="mt-1 text-sm text-brand-teal">{errors.purchaseTimeline}</p>
         )}
       </div>
       <div>
@@ -301,12 +301,12 @@ export default function OpenHouseSignInForm({ listingId, listingAddress }: Props
         </div>
       </div>
       {status === 'error' && (
-        <p className="text-red-600 font-medium">{errorMessage}</p>
+        <p className="text-brand-teal font-medium">{errorMessage}</p>
       )}
       <button
         type="submit"
         disabled={status === 'submitting'}
-        className="w-full rounded-lg bg-blue-600 px-4 py-4 text-lg font-semibold text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        className="w-full rounded-lg bg-brand-teal px-4 py-4 text-lg font-semibold text-white hover:bg-brand-plum disabled:opacity-50 transition-colors"
       >
         {status === 'submitting' ? 'Submitting…' : 'Submit'}
       </button>

--- a/components/PageIndexingEnhancement.tsx
+++ b/components/PageIndexingEnhancement.tsx
@@ -33,13 +33,13 @@ export default function PageIndexingEnhancement({
     <>
       <JsonLd data={speakable} />
       <section
-        className={`border-t border-gray-200 bg-gray-50 py-10 ${className}`}
+        className={`border-t border-brand-mint bg-brand-surface/60 py-10 ${className}`}
         aria-labelledby={`indexing-enhance-${path.replace(/\//g, '-')}`}
       >
         <div className="max-w-4xl mx-auto px-4">
           <h2
             id={`indexing-enhance-${path.replace(/\//g, '-')}`}
-            className="text-2xl font-bold text-gray-900 mb-3"
+            className="text-2xl font-bold text-brand-plum mb-3"
           >
             Quick answers
           </h2>
@@ -51,13 +51,13 @@ export default function PageIndexingEnhancement({
             className="indexing-related-links mb-10"
             aria-label="Related pages"
           >
-            <h3 className="text-lg font-semibold text-gray-900 mb-3">Explore next</h3>
+            <h3 className="text-lg font-semibold text-brand-plum mb-3">Explore next</h3>
             <ul className="flex flex-wrap gap-2">
               {content.relatedLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="inline-block rounded-full border border-blue-200 bg-white px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50 transition-colors"
+                    className="inline-block rounded-full border border-brand-mint bg-white px-4 py-2 text-sm font-medium text-brand-teal hover:bg-brand-mint/40 transition-colors"
                   >
                     {link.label}
                   </Link>

--- a/components/PropertyCard.tsx
+++ b/components/PropertyCard.tsx
@@ -42,7 +42,7 @@ export function PropertyCard({
           className="object-cover"
         />
         {openHouseDate && (
-          <Badge className="absolute top-2 right-2 bg-red-600 hover:bg-red-700">
+          <Badge className="absolute top-2 right-2 bg-brand-teal hover:bg-brand-plum">
             <Calendar className="h-3 w-3 mr-1" />
             Open House
           </Badge>
@@ -76,7 +76,7 @@ export function PropertyCard({
           </div>
         </div>
         {openHouseDate && (
-          <p className="mt-2 text-sm font-medium text-red-600">
+          <p className="mt-2 text-sm font-medium text-brand-teal">
             Open House: {openHouseDate}
           </p>
         )}

--- a/components/QRCodeGenerator.tsx
+++ b/components/QRCodeGenerator.tsx
@@ -90,7 +90,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
   return (
     <div className={`bg-white rounded-lg shadow-md p-6 ${className}`}>
       <div className="text-center mb-6">
-        <QrCode className="h-12 w-12 text-blue-600 mx-auto mb-4" />
+        <QrCode className="h-12 w-12 text-brand-teal mx-auto mb-4" />
         <h3 className="text-xl font-bold text-gray-900 mb-2">QR Code Generator</h3>
         <p className="text-gray-600">Generate QR codes for yard signs and marketing materials</p>
       </div>
@@ -104,7 +104,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
             type="text"
             value={propertyAddressState}
             onChange={(e) => setPropertyAddressState(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-teal focus:border-brand-teal"
             placeholder="Enter property address"
           />
         </div>
@@ -116,7 +116,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
           <select
             value={downloadFormat}
             onChange={(e) => setDownloadFormat(e.target.value as 'png' | 'svg')}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-teal focus:border-brand-teal"
             aria-label="Select download format"
             title="Select download format"
           >
@@ -130,7 +130,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
         <button
           onClick={generateQRCode}
           disabled={isGenerating}
-          className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-3 rounded-lg font-medium flex items-center"
+          className="bg-brand-teal hover:bg-brand-plum disabled:bg-gray-400 text-white px-6 py-3 rounded-lg font-medium flex items-center"
         >
           {isGenerating ? (
             <>
@@ -164,7 +164,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <button
               onClick={downloadQRCode}
-              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
+              className="bg-brand-teal hover:bg-brand-plum text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
             >
               <Download className="h-4 w-4 mr-2" />
               Download
@@ -180,7 +180,7 @@ const QRCodeGenerator: React.FC<QRCodeGeneratorProps> = ({
             
             <button
               onClick={shareQRCode}
-              className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
+              className="bg-brand-teal hover:bg-brand-plum text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center"
             >
               <Share2 className="h-4 w-4 mr-2" />
               Share

--- a/components/ReactHookForm.tsx
+++ b/components/ReactHookForm.tsx
@@ -126,17 +126,17 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
       
       {/* Success Message */}
       {submitStatus === 'success' && (
-        <div className="mb-6 p-4 bg-green-900 border border-green-600 rounded-lg flex items-center">
-          <CheckCircle className="h-5 w-5 text-green-400 mr-3" />
-          <span className="text-green-100">Thank you! We'll keep you updated on Summerlin West market changes.</span>
+        <div className="mb-6 p-4 bg-brand-plum border border-brand-teal rounded-lg flex items-center">
+          <CheckCircle className="h-5 w-5 text-brand-mint mr-3" />
+          <span className="text-brand-mint">Thank you! We'll keep you updated on Summerlin West market changes.</span>
         </div>
       )}
 
       {/* Error Message */}
       {submitStatus === 'error' && (
-        <div className="mb-6 p-4 bg-red-900 border border-red-600 rounded-lg flex items-center">
-          <AlertCircle className="h-5 w-5 text-red-400 mr-3" />
-          <span className="text-red-100">{errorMessage}</span>
+        <div className="mb-6 p-4 bg-brand-plum border border-brand-plum rounded-lg flex items-center">
+          <AlertCircle className="h-5 w-5 text-brand-plum mr-3" />
+          <span className="text-brand-mint">{errorMessage}</span>
         </div>
       )}
       
@@ -152,12 +152,12 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
               type="text"
               placeholder="Your Name"
               className={`w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border text-white placeholder-gray-400 focus:outline-none ${
-                errors.name ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-blue-500'
+                errors.name ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-600 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.name && (
-            <p className="mt-1 text-sm text-red-400">{errors.name.message}</p>
+            <p className="mt-1 text-sm text-brand-plum">{errors.name.message}</p>
           )}
         </div>
         
@@ -175,12 +175,12 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
               type="email"
               placeholder="Email Address"
               className={`w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border text-white placeholder-gray-400 focus:outline-none ${
-                errors.email ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-blue-500'
+                errors.email ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-600 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.email && (
-            <p className="mt-1 text-sm text-red-400">{errors.email.message}</p>
+            <p className="mt-1 text-sm text-brand-plum">{errors.email.message}</p>
           )}
         </div>
         
@@ -197,12 +197,12 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
               type="tel"
               placeholder="Phone Number (optional)"
               className={`w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border text-white placeholder-gray-400 focus:outline-none ${
-                errors.phone ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-blue-500'
+                errors.phone ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-600 focus:border-brand-teal'
               }`}
             />
           </div>
           {errors.phone && (
-            <p className="mt-1 text-sm text-red-400">{errors.phone.message}</p>
+            <p className="mt-1 text-sm text-brand-plum">{errors.phone.message}</p>
           )}
         </div>
         
@@ -216,7 +216,7 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
               aria-label="Select interested neighborhood"
               title="Select interested neighborhood"
               className={`w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 border text-white focus:outline-none ${
-                errors.neighborhood ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-blue-500'
+                errors.neighborhood ? 'border-brand-plum focus:border-brand-plum' : 'border-gray-600 focus:border-brand-teal'
               }`}
             >
               <option value="">Select Neighborhood</option>
@@ -228,14 +228,14 @@ const ReactHookForm: React.FC<ReactHookFormProps> = ({
             </select>
           </div>
           {errors.neighborhood && (
-            <p className="mt-1 text-sm text-red-400">{errors.neighborhood.message}</p>
+            <p className="mt-1 text-sm text-brand-plum">{errors.neighborhood.message}</p>
           )}
         </div>
         
         <button 
           type="submit"
           disabled={isSubmitting}
-          className="w-full bg-red-600 hover:bg-red-700 disabled:bg-red-800 text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center disabled:cursor-not-allowed"
+          className="w-full bg-brand-teal hover:bg-brand-plum disabled:bg-brand-stone text-white px-4 py-2 rounded-lg font-medium flex items-center justify-center disabled:cursor-not-allowed"
         >
           {isSubmitting ? (
             <>

--- a/components/RealScoutIntegration.tsx
+++ b/components/RealScoutIntegration.tsx
@@ -20,26 +20,26 @@ const RealScoutIntegration = () => {
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
       <div className="text-center mb-6">
-        <Home className="h-12 w-12 text-blue-600 mx-auto mb-4" />
+        <Home className="h-12 w-12 text-brand-teal mx-auto mb-4" />
         <h3 className="text-xl font-bold text-gray-900 mb-2">Find Your Dream Home</h3>
         <p className="text-gray-600">Search all Summerlin listings with Dr. Jan Duffy's home search</p>
       </div>
 
       <div className="space-y-4 mb-6">
         <div className="flex items-center">
-          <Search className="h-5 w-5 text-blue-600 mr-3" />
+          <Search className="h-5 w-5 text-brand-teal mr-3" />
           <span className="text-gray-700">Advanced search filters</span>
         </div>
         <div className="flex items-center">
-          <Heart className="h-5 w-5 text-blue-600 mr-3" />
+          <Heart className="h-5 w-5 text-brand-teal mr-3" />
           <span className="text-gray-700">Save favorite properties</span>
         </div>
         <div className="flex items-center">
-          <Calendar className="h-5 w-5 text-blue-600 mr-3" />
+          <Calendar className="h-5 w-5 text-brand-teal mr-3" />
           <span className="text-gray-700">Schedule private showings</span>
         </div>
         <div className="flex items-center">
-          <Star className="h-5 w-5 text-blue-600 mr-3" />
+          <Star className="h-5 w-5 text-brand-teal mr-3" />
           <span className="text-gray-700">Get market insights</span>
         </div>
       </div>
@@ -47,7 +47,7 @@ const RealScoutIntegration = () => {
       <div className="space-y-3">
         <button
           onClick={openRealScoutSearch}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 rounded-lg font-medium flex items-center justify-center"
+          className="w-full bg-brand-teal hover:bg-brand-plum text-white px-4 py-3 rounded-lg font-medium flex items-center justify-center"
         >
           <Search className="h-4 w-4 mr-2" />
           Start Your Search
@@ -68,7 +68,7 @@ const RealScoutIntegration = () => {
              <Phone className="h-4 w-4 mr-1" />
              <a 
                href={`tel:${GBP.phoneE164}`}
-               className="hover:text-blue-600 transition-colors cursor-pointer"
+               className="hover:text-brand-plum transition-colors cursor-pointer"
                title={`Call ${GBP.phone}`}
              >
                {GBP.phone}

--- a/components/RealScoutOfficeListingsBands.tsx
+++ b/components/RealScoutOfficeListingsBands.tsx
@@ -20,7 +20,7 @@ export default function RealScoutOfficeListingsBands() {
           </h2>
           <p className="mt-2 text-gray-600">
             Live MLS listings from Dr. Jan Duffy — $400K to $900K, sorted low to high. For more filters, use the{' '}
-            <a href="/tour/mls" className="font-semibold text-blue-600 hover:underline">
+            <a href="/tour/mls" className="font-semibold text-brand-teal hover:underline">
               full MLS search
             </a>
             .

--- a/components/RealScoutSearchCard.tsx
+++ b/components/RealScoutSearchCard.tsx
@@ -28,7 +28,7 @@ export default function RealScoutSearchCard() {
           <div className="animate-pulse">
             <div className="h-12 bg-gray-200 rounded-lg mb-3"></div>
             <div className="h-12 bg-gray-200 rounded-lg mb-3"></div>
-            <div className="h-12 bg-red-200 rounded-lg"></div>
+            <div className="h-12 bg-brand-mint rounded-lg"></div>
           </div>
         )}
         {/* @ts-expect-error - Web component is defined at runtime */}
@@ -41,15 +41,15 @@ export default function RealScoutSearchCard() {
 
       <div className="grid grid-cols-3 gap-4 pt-4 border-t border-gray-200 mt-6">
         <div className="text-center">
-          <div className="text-lg sm:text-2xl font-bold text-blue-600">6</div>
+          <div className="text-lg sm:text-2xl font-bold text-brand-teal">6</div>
           <div className="text-xs text-gray-600">Open Houses</div>
         </div>
         <div className="text-center">
-          <div className="text-lg sm:text-2xl font-bold text-blue-600">14</div>
+          <div className="text-lg sm:text-2xl font-bold text-brand-teal">14</div>
           <div className="text-xs text-gray-600">Avg Days</div>
         </div>
         <div className="text-center">
-          <div className="text-lg sm:text-2xl font-bold text-blue-600">98%</div>
+          <div className="text-lg sm:text-2xl font-bold text-brand-teal">98%</div>
           <div className="text-xs text-gray-600">Success Rate</div>
         </div>
       </div>
@@ -57,7 +57,7 @@ export default function RealScoutSearchCard() {
       <div className="mt-4 text-center">
         <ExternalLink
           href="https://drjanduffy.realscout.com"
-          className="inline-block py-2.5 text-sm text-blue-600 hover:text-blue-700 font-medium"
+          className="inline-block py-2.5 text-sm text-brand-teal hover:text-brand-plum font-medium"
           showIcon={false}
         >
           Advanced Search Options →

--- a/components/RelatedNeighborhoods.tsx
+++ b/components/RelatedNeighborhoods.tsx
@@ -34,7 +34,7 @@ export default function RelatedNeighborhoods({ currentSlug, className = '' }: Re
   if (!related || related.length === 0) {
     return (
       <p className={`text-gray-700 ${className}`}>
-        Explore <Link href="/neighborhoods" className="text-blue-600 font-semibold hover:underline">all Summerlin neighborhoods</Link> for community info and homes for sale.
+        Explore <Link href="/neighborhoods" className="text-brand-teal font-semibold hover:underline">all Summerlin neighborhoods</Link> for community info and homes for sale.
       </p>
     )
   }
@@ -48,15 +48,15 @@ export default function RelatedNeighborhoods({ currentSlug, className = '' }: Re
   const [first, second, third] = links
   return (
     <p className={`text-gray-700 ${className}`}>
-      Explore <Link href="/neighborhoods" className="text-blue-600 font-semibold hover:underline">all Summerlin neighborhoods</Link>
+      Explore <Link href="/neighborhoods" className="text-brand-teal font-semibold hover:underline">all Summerlin neighborhoods</Link>
       {first && links.length === 1 && (
-        <> or see <Link href={first.href} className="text-blue-600 font-semibold hover:underline">{first.name}</Link>.</>
+        <> or see <Link href={first.href} className="text-brand-teal font-semibold hover:underline">{first.name}</Link>.</>
       )}
       {first && second && links.length === 2 && (
-        <> or see <Link href={first.href} className="text-blue-600 font-semibold hover:underline">{first.name}</Link> and <Link href={second.href} className="text-blue-600 font-semibold hover:underline">{second.name}</Link>.</>
+        <> or see <Link href={first.href} className="text-brand-teal font-semibold hover:underline">{first.name}</Link> and <Link href={second.href} className="text-brand-teal font-semibold hover:underline">{second.name}</Link>.</>
       )}
       {first && second && third && links.length >= 3 && (
-        <> or see <Link href={first.href} className="text-blue-600 font-semibold hover:underline">{first.name}</Link>, <Link href={second.href} className="text-blue-600 font-semibold hover:underline">{second.name}</Link>, and <Link href={third.href} className="text-blue-600 font-semibold hover:underline">{third.name}</Link>.</>
+        <> or see <Link href={first.href} className="text-brand-teal font-semibold hover:underline">{first.name}</Link>, <Link href={second.href} className="text-brand-teal font-semibold hover:underline">{second.name}</Link>, and <Link href={third.href} className="text-brand-teal font-semibold hover:underline">{third.name}</Link>.</>
       )}
     </p>
   )

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -65,7 +65,7 @@ function NavDropdown({ group }: { group: NavGroup }) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-0.5 px-3 py-2 rounded-lg text-gray-700 hover:text-blue-600 hover:bg-blue-50 font-medium transition-colors"
+        className="flex items-center gap-0.5 px-3 py-2 rounded-lg text-gray-700 hover:text-brand-teal hover:bg-brand-mint/40 font-medium transition-colors"
         aria-expanded={open}
         aria-haspopup="true"
         aria-controls={`nav-menu-${group.label.replace(/\s+/g, '-')}`}
@@ -88,7 +88,7 @@ function NavDropdown({ group }: { group: NavGroup }) {
                 className={
                   primary
                     ? 'block px-4 py-2 text-red-600 hover:bg-red-50 font-semibold'
-                    : 'block px-4 py-2 text-gray-700 hover:bg-blue-50 hover:text-blue-600 font-medium'
+                    : 'block px-4 py-2 text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium'
                 }
                 onClick={() => setOpen(false)}
               >
@@ -111,14 +111,14 @@ export default function SiteHeader() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16 md:h-18">
           {/* Calendly widget CTA (replaces logo) */}
-          <CalendlyPopupLink className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-[#0069ff] text-white hover:bg-[#0052cc] font-semibold transition-colors min-h-[44px]">
+          <CalendlyPopupLink className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-brand-teal text-white hover:bg-brand-plum font-semibold transition-colors min-h-[44px]">
             <Calendar className="h-5 w-5 shrink-0" aria-hidden />
             <span>Book a showing</span>
           </CalendlyPopupLink>
 
           {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-1" aria-label="Main">
-            <Link href="/" className="px-3 py-2 rounded-lg text-gray-700 hover:text-blue-600 hover:bg-blue-50 font-medium transition-colors">
+            <Link href="/" className="px-3 py-2 rounded-lg text-gray-700 hover:text-brand-teal hover:bg-brand-mint/40 font-medium transition-colors">
               Home
             </Link>
             <Link href="/tour/mls" className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 font-semibold transition-colors">
@@ -131,14 +131,14 @@ export default function SiteHeader() {
               <Link
                 key={href}
                 href={href}
-                className="px-3 py-2 rounded-lg text-gray-700 hover:text-blue-600 hover:bg-blue-50 font-medium transition-colors"
+                className="px-3 py-2 rounded-lg text-gray-700 hover:text-brand-teal hover:bg-brand-mint/40 font-medium transition-colors"
               >
                 {label}
               </Link>
             ))}
             {/* Appointment CTAs – visible for one-click booking */}
             <span className="ml-2 flex items-center gap-1 border-l border-gray-200 pl-2">
-              <CalendlyPopupLink className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-[#0069ff] text-white hover:bg-[#0052cc] font-semibold transition-colors">
+              <CalendlyPopupLink className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-teal text-white hover:bg-brand-plum font-semibold transition-colors">
                 <Calendar className="h-4 w-4" aria-hidden />
                 <span>Book a showing</span>
               </CalendlyPopupLink>
@@ -151,7 +151,7 @@ export default function SiteHeader() {
               </Link>
               <a
                 href={PHONE.href}
-                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-semibold transition-colors"
+                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-plum text-white hover:bg-brand-teal font-semibold transition-colors"
               >
                 <Phone className="h-4 w-4" aria-hidden />
                 <span>{PHONE.display}</span>
@@ -179,7 +179,7 @@ export default function SiteHeader() {
           >
             <ul className="space-y-1">
               <li>
-                <Link href="/" onClick={() => setMobileOpen(false)} className="block px-4 py-3 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-600 font-medium">
+                <Link href="/" onClick={() => setMobileOpen(false)} className="block px-4 py-3 rounded-lg text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium">
                   Home
                 </Link>
               </li>
@@ -187,7 +187,7 @@ export default function SiteHeader() {
               <li className="pt-2 pb-2 border-b border-gray-200">
                 <p className="px-4 text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Book now</p>
                 <div className="flex flex-col gap-2">
-                  <CalendlyPopupLink className="flex items-center gap-2 px-4 py-3 rounded-lg bg-[#0069ff] text-white hover:bg-[#0052cc] font-semibold">
+                  <CalendlyPopupLink className="flex items-center gap-2 px-4 py-3 rounded-lg bg-brand-teal text-white hover:bg-brand-plum font-semibold">
                     <Calendar className="h-4 w-4" aria-hidden />
                     Book a showing
                   </CalendlyPopupLink>
@@ -215,7 +215,7 @@ export default function SiteHeader() {
                     <button
                       type="button"
                       onClick={() => setMobileGroupOpen(isOpen ? null : group.label)}
-                      className="flex w-full items-center justify-between px-4 py-3 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-600 font-medium"
+                      className="flex w-full items-center justify-between px-4 py-3 rounded-lg text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium"
                       aria-expanded={isOpen}
                     >
                       {group.label}
@@ -231,7 +231,7 @@ export default function SiteHeader() {
                               className={
                                 primary
                                   ? 'block px-3 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 font-semibold text-sm'
-                                  : 'block px-3 py-2 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-600 font-medium text-sm'
+                                  : 'block px-3 py-2 rounded-lg text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium text-sm'
                               }
                             >
                               {label}
@@ -248,7 +248,7 @@ export default function SiteHeader() {
                   <Link
                     href={href}
                     onClick={() => setMobileOpen(false)}
-                    className="block px-4 py-3 rounded-lg text-gray-700 hover:bg-blue-50 hover:text-blue-600 font-medium"
+                    className="block px-4 py-3 rounded-lg text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium"
                   >
                     {label}
                   </Link>

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -87,7 +87,7 @@ function NavDropdown({ group }: { group: NavGroup }) {
                 href={href}
                 className={
                   primary
-                    ? 'block px-4 py-2 text-red-600 hover:bg-red-50 font-semibold'
+                    ? 'block px-4 py-2 text-brand-teal hover:bg-brand-mint/30 font-semibold'
                     : 'block px-4 py-2 text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium'
                 }
                 onClick={() => setOpen(false)}
@@ -121,7 +121,7 @@ export default function SiteHeader() {
             <Link href="/" className="px-3 py-2 rounded-lg text-gray-700 hover:text-brand-teal hover:bg-brand-mint/40 font-medium transition-colors">
               Home
             </Link>
-            <Link href="/tour/mls" className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 font-semibold transition-colors">
+            <Link href="/tour/mls" className="px-4 py-2 rounded-lg bg-brand-teal text-white hover:bg-brand-plum font-semibold transition-colors">
               Search Listings
             </Link>
             {NAV_GROUPS.map((group) => (
@@ -201,7 +201,7 @@ export default function SiteHeader() {
                   </Link>
                   <a
                     href={PHONE.href}
-                    className="flex items-center gap-2 px-4 py-3 rounded-lg bg-blue-600 text-white font-semibold"
+                    className="flex items-center gap-2 px-4 py-3 rounded-lg bg-brand-plum text-white font-semibold"
                   >
                     <Phone className="h-4 w-4" aria-hidden />
                     {PHONE.display}
@@ -230,7 +230,7 @@ export default function SiteHeader() {
                               onClick={() => setMobileOpen(false)}
                               className={
                                 primary
-                                  ? 'block px-3 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 font-semibold text-sm'
+                                  ? 'block px-3 py-2 rounded-lg bg-brand-teal text-white hover:bg-brand-plum font-semibold text-sm'
                                   : 'block px-3 py-2 rounded-lg text-gray-700 hover:bg-brand-mint/40 hover:text-brand-teal font-medium text-sm'
                               }
                             >

--- a/components/StoreLocationsMap.tsx
+++ b/components/StoreLocationsMap.tsx
@@ -88,9 +88,9 @@ export default function StoreLocationsMap({ locations, className = '' }: StoreLo
         <div class="p-3 min-w-[200px]">
           <div class="font-semibold text-gray-900 mb-1">${loc.name}</div>
           <div class="text-sm text-gray-600 mb-2">${loc.address}, ${loc.city}, ${loc.state} ${loc.zip}</div>
-          ${loc.phone ? `<div class="text-sm mb-2"><a href="tel:+1${loc.phone.replace(/\D/g, '')}" class="text-blue-600 hover:underline">${loc.phone}</a></div>` : ''}
+          ${loc.phone ? `<div class="text-sm mb-2"><a href="tel:+1${loc.phone.replace(/\D/g, '')}" class="text-brand-teal hover:underline">${loc.phone}</a></div>` : ''}
           ${loc.hours ? `<div class="text-xs text-gray-500 mb-2">${loc.hours}</div>` : ''}
-          <a href="${loc.directionsUrl}" target="_blank" rel="noopener noreferrer" class="text-sm font-medium text-blue-600 hover:underline">Get directions</a>
+          <a href="${loc.directionsUrl}" target="_blank" rel="noopener noreferrer" class="text-sm font-medium text-brand-teal hover:underline">Get directions</a>
         </div>
       `
       marker.addListener('click', () => {
@@ -125,13 +125,13 @@ export default function StoreLocationsMap({ locations, className = '' }: StoreLo
           >
             <h3 className="font-semibold text-gray-900 mb-2">{loc.name}</h3>
             <div className="flex items-start gap-2 text-sm text-gray-600 mb-2">
-              <MapPin className="h-4 w-4 shrink-0 mt-0.5 text-blue-600" aria-hidden />
+              <MapPin className="h-4 w-4 shrink-0 mt-0.5 text-brand-teal" aria-hidden />
               <span>{loc.address}, {loc.city}, {loc.state} {loc.zip}</span>
             </div>
             {loc.phone && (
               <div className="flex items-center gap-2 text-sm mb-2">
-                <Phone className="h-4 w-4 shrink-0 text-blue-600" aria-hidden />
-                <a href={`tel:+1${loc.phone.replace(/\D/g, '')}`} className="text-blue-600 hover:underline">
+                <Phone className="h-4 w-4 shrink-0 text-brand-teal" aria-hidden />
+                <a href={`tel:+1${loc.phone.replace(/\D/g, '')}`} className="text-brand-teal hover:underline">
                   {loc.phone}
                 </a>
               </div>
@@ -146,7 +146,7 @@ export default function StoreLocationsMap({ locations, className = '' }: StoreLo
               href={loc.directionsUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:text-blue-800"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-teal hover:text-brand-plum"
             >
               <Navigation className="h-4 w-4" aria-hidden />
               Get directions
@@ -165,7 +165,7 @@ export default function StoreLocationsMap({ locations, className = '' }: StoreLo
         {!isLoaded && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-100 rounded-xl">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-10 w-10 border-2 border-blue-600 border-t-transparent mx-auto mb-3" />
+              <div className="animate-spin rounded-full h-10 w-10 border-2 border-brand-teal border-t-transparent mx-auto mb-3" />
               <p className="text-sm text-gray-600">Loading map...</p>
             </div>
           </div>

--- a/components/SummerlinOpenHouseWebsite.tsx
+++ b/components/SummerlinOpenHouseWebsite.tsx
@@ -86,7 +86,7 @@ const SummerlinOpenHouseWebsite = () => {
                    )}
                  </div>
                  <div>
-                   <p className="text-blue-200 text-sm font-medium">DR. JAN DUFFY</p>
+                   <p className="text-brand-mint text-sm font-medium">DR. JAN DUFFY</p>
                    <p className="text-white text-lg font-semibold">Your Local Research-Driven Expert</p>
                  </div>
                </div>
@@ -94,7 +94,7 @@ const SummerlinOpenHouseWebsite = () => {
                <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 leading-tight">
                  {SEO_PRIMARY_KEYWORD}
                </h1>
-               <p className="text-lg sm:text-xl font-semibold text-blue-100 mb-4">
+               <p className="text-lg sm:text-xl font-semibold text-brand-mint/90 mb-4">
                  Your local research-driven expert for Summerlin West &amp; Las Vegas—Dr. Jan Duffy, {GBP.name}
                </p>
                <p className="text-base sm:text-xl mb-4 text-white">
@@ -257,7 +257,7 @@ const SummerlinOpenHouseWebsite = () => {
                     <p className="text-brand-teal font-semibold mb-3">{neighborhood.priceRange}</p>
                     <div className="flex flex-wrap gap-2 mb-3">
                       {neighborhood.highlights.map(highlight => (
-                        <span key={highlight} className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-sm">
+                        <span key={highlight} className="bg-brand-mint text-brand-plum px-2 py-1 rounded text-sm">
                           {highlight}
                         </span>
                       ))}

--- a/components/SummerlinOpenHouseWebsite.tsx
+++ b/components/SummerlinOpenHouseWebsite.tsx
@@ -60,7 +60,7 @@ const SummerlinOpenHouseWebsite = () => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-       <section className="bg-gradient-to-r from-blue-600 to-red-600 text-white py-10 sm:py-12 lg:py-16 rounded-b-3xl">
+       <section className="bg-gradient-to-r from-brand-plum to-brand-teal text-white py-10 sm:py-12 lg:py-16 rounded-b-3xl">
          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
              {/* Left Column - Content */}
@@ -122,7 +122,7 @@ const SummerlinOpenHouseWebsite = () => {
                {/* Primary CTA: RealScout / Search Listings */}
                <Link
                  href="/tour/mls"
-                 className="inline-flex items-center justify-center min-h-[44px] bg-white text-blue-600 hover:bg-gray-50 px-8 py-4 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl transition-all duration-200"
+                 className="inline-flex items-center justify-center min-h-[44px] bg-white text-brand-teal hover:bg-gray-50 px-8 py-4 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl transition-all duration-200"
                >
                  Search Summerlin Listings
                </Link>
@@ -155,7 +155,7 @@ const SummerlinOpenHouseWebsite = () => {
             ))}
           </dl>
           <p className="mt-8 text-center">
-            <Link href="/open-houses" className="font-semibold text-blue-600 hover:underline">
+            <Link href="/open-houses" className="font-semibold text-brand-teal hover:underline">
               Open Houses hub: tours, FAQs, and scheduling →
             </Link>
           </p>
@@ -171,23 +171,23 @@ const SummerlinOpenHouseWebsite = () => {
             </h2>
             <p className="text-lg text-gray-600">
               Browse{' '}
-              <a href="#office-listings-bands" className="font-semibold text-blue-600 hover:underline">
+              <a href="#office-listings-bands" className="font-semibold text-brand-teal hover:underline">
                 office MLS listings
               </a>{' '}
               ($400K–$900K), or use the full{' '}
-              <Link href="/tour/mls" className="font-semibold text-blue-600 hover:underline">
+              <Link href="/tour/mls" className="font-semibold text-brand-teal hover:underline">
                 MLS property search
               </Link>{' '}
               and{' '}
-              <Link href="/open-houses" className="font-semibold text-blue-600 hover:underline">
+              <Link href="/open-houses" className="font-semibold text-brand-teal hover:underline">
                 open houses hub
               </Link>
               . For market context, see the{' '}
-              <Link href="/market-report" className="font-semibold text-blue-600 hover:underline">
+              <Link href="/market-report" className="font-semibold text-brand-teal hover:underline">
                 market report
               </Link>{' '}
               or{' '}
-              <Link href="/book-tour" className="font-semibold text-blue-600 hover:underline">
+              <Link href="/book-tour" className="font-semibold text-brand-teal hover:underline">
                 schedule a showing
               </Link>
               .
@@ -251,10 +251,10 @@ const SummerlinOpenHouseWebsite = () => {
                   </Link>
                   <div className="p-6">
                     <Link href={neighborhoodUrl}>
-                      <h3 className="text-xl font-bold text-gray-900 mb-2 hover:text-blue-600">{neighborhood.name}</h3>
+                      <h3 className="text-xl font-bold text-gray-900 mb-2 hover:text-brand-teal">{neighborhood.name}</h3>
                     </Link>
                     <p className="text-gray-600 mb-3">{neighborhood.description}</p>
-                    <p className="text-blue-600 font-semibold mb-3">{neighborhood.priceRange}</p>
+                    <p className="text-brand-teal font-semibold mb-3">{neighborhood.priceRange}</p>
                     <div className="flex flex-wrap gap-2 mb-3">
                       {neighborhood.highlights.map(highlight => (
                         <span key={highlight} className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-sm">
@@ -264,7 +264,7 @@ const SummerlinOpenHouseWebsite = () => {
                     </div>
                     <Link 
                       href={neighborhoodUrl}
-                      className="inline-block text-blue-600 hover:text-blue-800 font-medium text-sm"
+                      className="inline-block text-brand-teal hover:text-brand-plum font-medium text-sm"
                     >
                       Explore {neighborhood.name} →
                     </Link>
@@ -274,10 +274,10 @@ const SummerlinOpenHouseWebsite = () => {
             })}
           </div>
           <div className="text-center mt-6 flex flex-wrap justify-center gap-x-4 gap-y-1">
-            <Link href="/neighborhoods" className="text-blue-600 font-semibold hover:underline">
+            <Link href="/neighborhoods" className="text-brand-teal font-semibold hover:underline">
               Explore all neighborhoods →
             </Link>
-            <Link href="/sitemap" className="text-blue-600 font-semibold hover:underline">
+            <Link href="/sitemap" className="text-brand-teal font-semibold hover:underline">
               Browse full sitemap
             </Link>
           </div>
@@ -290,20 +290,20 @@ const SummerlinOpenHouseWebsite = () => {
           <p className="text-lg text-gray-700 italic max-w-2xl mx-auto mb-2">
             &ldquo;Dr. Jan found us the perfect home in The Ridges within 2 weeks. Her market knowledge is incredible!&rdquo; — Sarah & Mike Johnson
           </p>
-          <Link href="/review-us" className="text-blue-600 font-semibold hover:underline">
+          <Link href="/review-us" className="text-brand-teal font-semibold hover:underline">
             Read more reviews
           </Link>
         </div>
       </section>
 
       {/* Compact RealScout CTA band */}
-      <section className="bg-blue-600 text-white py-8 sm:py-10">
+      <section className="bg-brand-plum text-white py-8 sm:py-10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h3 className="text-2xl font-bold mb-2">Never miss your dream home</h3>
           <p className="text-white mb-4">Get instant alerts for new listings, price drops, and open houses in Summerlin West.</p>
           <Link
             href="/tour/mls"
-            className="inline-flex items-center justify-center min-h-[44px] bg-white text-blue-600 hover:bg-gray-50 px-6 py-3 rounded-lg font-bold transition-colors"
+            className="inline-flex items-center justify-center min-h-[44px] bg-white text-brand-teal hover:bg-gray-50 px-6 py-3 rounded-lg font-bold transition-colors"
           >
             Search Listings & Get Alerts
           </Link>
@@ -319,11 +319,11 @@ const SummerlinOpenHouseWebsite = () => {
           </p>
           <p className="text-gray-400 text-sm mb-4">{GBP.address.street}, {GBP.address.locality}, {GBP.address.region} {GBP.address.postalCode}</p>
           <div className="flex flex-wrap justify-center gap-4">
-            <a href={`tel:${GBP.phoneE164}`} className="inline-flex items-center justify-center min-h-[44px] gap-2 bg-blue-600 hover:bg-blue-700 px-5 py-2.5 rounded-lg font-medium">
+            <a href={`tel:${GBP.phoneE164}`} className="inline-flex items-center justify-center min-h-[44px] gap-2 bg-brand-teal hover:bg-brand-mint hover:text-brand-plum px-5 py-2.5 rounded-lg font-medium">
               <Phone className="h-4 w-4" aria-hidden />
               Call {GBP.phone}
             </a>
-            <Link href="/book-tour" className="inline-flex items-center justify-center min-h-[44px] gap-2 bg-[#0069ff] hover:bg-[#0052cc] px-5 py-2.5 rounded-lg font-medium text-white">
+            <Link href="/book-tour" className="inline-flex items-center justify-center min-h-[44px] gap-2 bg-brand-teal hover:bg-brand-plum px-5 py-2.5 rounded-lg font-medium text-white">
               <Calendar className="h-4 w-4" aria-hidden />
               Schedule a showing
             </Link>

--- a/components/VirtualTourBadge.tsx
+++ b/components/VirtualTourBadge.tsx
@@ -17,7 +17,7 @@ export function VirtualTourBadge({ onClick, className }: VirtualTourBadgeProps) 
         onClick()
       }}
       className={cn(
-        'absolute bottom-3 right-3 flex items-center gap-1.5 rounded bg-black/70 px-2 py-1.5 text-xs font-medium text-white transition hover:bg-black/85 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1',
+        'absolute bottom-3 right-3 flex items-center gap-1.5 rounded bg-black/70 px-2 py-1.5 text-xs font-medium text-white transition hover:bg-black/85 focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-1',
         className
       )}
       aria-label="Open virtual tour"

--- a/components/VirtualTourModal.tsx
+++ b/components/VirtualTourModal.tsx
@@ -69,7 +69,7 @@ export function VirtualTourModal({ isOpen, onClose, url, title }: VirtualTourMod
           <button
             type="button"
             onClick={handleFullscreen}
-            className="flex items-center gap-2 rounded bg-gray-700 px-3 py-2 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="flex items-center gap-2 rounded bg-gray-700 px-3 py-2 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-brand-teal"
             aria-label="Toggle fullscreen"
           >
             <Maximize className="h-4 w-4" />
@@ -78,7 +78,7 @@ export function VirtualTourModal({ isOpen, onClose, url, title }: VirtualTourMod
           <button
             type="button"
             onClick={onClose}
-            className="flex items-center gap-2 rounded bg-gray-700 px-3 py-2 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="flex items-center gap-2 rounded bg-gray-700 px-3 py-2 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-brand-teal"
             aria-label="Close virtual tour"
           >
             <X className="h-4 w-4" />

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,16 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-blue-600 text-white hover:bg-blue-700",
+          "border-transparent bg-brand-teal text-white hover:bg-brand-plum",
         secondary:
           "border-transparent bg-gray-200 text-gray-900 hover:bg-gray-300",
         destructive:
-          "border-transparent bg-red-600 text-white hover:bg-red-700",
+          "border-transparent bg-brand-teal text-white hover:bg-brand-plum",
         outline: "text-gray-900",
       },
     },

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,19 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
       variants: {
         variant: {
-          default: "bg-blue-600 text-white hover:bg-blue-700",
+          default: "bg-brand-teal text-white hover:bg-brand-plum",
           destructive:
-            "bg-red-600 text-white hover:bg-red-700",
+            "bg-brand-teal text-white hover:bg-brand-plum",
           outline:
             "border border-gray-300 bg-white hover:bg-gray-50 hover:text-gray-900",
           secondary:
             "bg-gray-200 text-gray-900 hover:bg-gray-300",
           ghost: "hover:bg-gray-100 hover:text-gray-900",
-          link: "text-blue-600 underline-offset-4 hover:underline",
+          link: "text-brand-teal underline-offset-4 hover:underline",
         },
       size: {
         default: "h-10 px-4 py-2",

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-brand-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-teal data-[state=checked]:text-white",
       className
     )}
     {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-gray-100 data-[state=open]:text-gray-600">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-gray-100 data-[state=open]:text-gray-600">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-teal focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/config/brand.ts
+++ b/config/brand.ts
@@ -1,0 +1,24 @@
+/**
+ * Open House Market Place brand palette (site-wide).
+ * Use Tailwind utilities: brand-plum, brand-teal, brand-mint, brand-stone, brand-surface.
+ */
+export const BRAND_COLORS = {
+  plum: '#4a3861',
+  teal: '#6399a3',
+  mint: '#b8dad7',
+  stone: '#ada3a1',
+  surface: '#e5e7eb',
+} as const
+
+/** RGB tuples for docs / tooling */
+export const BRAND_RGB = {
+  plum: [74, 56, 97] as const,
+  teal: [99, 153, 163] as const,
+  mint: [184, 218, 215] as const,
+  stone: [173, 163, 161] as const,
+  surface: [229, 231, 235] as const,
+} as const
+
+/** Default primary CTA button classes (Calendly, schedule links) */
+export const BRAND_CTA_BUTTON_CLASS =
+  'inline-flex items-center justify-center bg-brand-teal hover:bg-brand-plum text-white font-semibold transition-colors' as const

--- a/config/gbp.ts
+++ b/config/gbp.ts
@@ -79,6 +79,8 @@ export const GBP = {
   phoneE164: '+17022003422',
   /** SMS/Chat from GBP */
   sms: 'sms:+17022003422',
+  /** Public contact email (site-wide; match GBP and legal pages) */
+  email: 'DrJanSells@OpenHouseMarketplace.com',
   /** Public site URL for schema (use getSiteUrl() = canonical, typically https://www.openhousemarketplace.com) */
   website: `${getSiteUrl()}/`,
   /**

--- a/config/indexing-pages.ts
+++ b/config/indexing-pages.ts
@@ -3,7 +3,7 @@
  * Visible FAQs + speakable summaries (AEO) and internal links (SEO).
  */
 import type { FaqItem } from '@/lib/json-ld'
-import { GBP } from '@/config/gbp'
+import { GBP, GBP_SERVICE_AREA } from '@/config/gbp'
 import { AGENT_LICENSE, AGENT_MEMBER_OF, AGENT_NAME, SEO_PRIMARY_KEYWORD } from '@/config/seo'
 
 export type IndexingPageContent = {
@@ -530,6 +530,199 @@ export const INDEXING_PAGE_CONTENT: Record<string, IndexingPageContent> = {
     'willows',
     '89138',
     'tree-lined streets and walkable blocks'
+  ),
+  '/': {
+    speakableSummary: `${SEO_PRIMARY_KEYWORD} in Summerlin West and Las Vegas—weekend tours, MLS search, and private showings with ${AGENT} at ${SITE}.`,
+    faqs: [
+      {
+        question: 'Where can I find Summerlin Las Vegas open houses this weekend?',
+        answer: `Browse featured listings on the homepage, visit /open-houses, or search MLS at /tour/mls. Call ${PHONE} or book at /book-tour for a private showing.`,
+      },
+      {
+        question: 'Who is Dr. Jan Duffy?',
+        answer: `${AGENT} is a licensed Nevada real estate professional (${AGENT_LICENSE}) specializing in Summerlin West open houses, luxury homes, and buyer representation.`,
+      },
+      {
+        question: 'What areas does Open House Market Place serve?',
+        answer: `Summerlin West, Summerlin villages, and Las Vegas zip codes ${GBP_SERVICE_AREA.zipCodes.join(', ')}—plus Henderson and North Las Vegas via MLS search.`,
+      },
+    ],
+    relatedLinks: [
+      { href: '/open-houses', label: 'Open houses hub' },
+      { href: '/book-tour', label: 'Schedule a showing' },
+      { href: '/tour/mls', label: 'MLS search' },
+      { href: '/market-report', label: 'Market report' },
+    ],
+  },
+  '/open-houses': {
+    speakableSummary: `Browse ${SEO_PRIMARY_KEYWORD} with weekend tour times, neighborhood context, and links to schedule a private showing with ${AGENT}.`,
+    faqs: [
+      {
+        question: 'When are Summerlin open houses usually held?',
+        answer: 'Most open houses run Saturday and Sunday; hours vary by listing. Check each property for posted times or book a private tour.',
+      },
+      {
+        question: 'How do I schedule a private showing instead of an open house?',
+        answer: `Use /book-tour or call ${PHONE}. Private tours can be arranged for many Summerlin listings outside public open house hours.`,
+      },
+      {
+        question: 'Which Summerlin neighborhoods have the most open houses?',
+        answer: 'Activity varies weekly—The Ridges, Red Rock Country Club, Summerlin Centre, The Trails, and 89138 corridors often have tours.',
+      },
+    ],
+    relatedLinks: [
+      { href: '/open-house-guide', label: 'Open house guide 2026' },
+      { href: '/luxury-homes', label: 'Luxury homes' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/open-house-guide': {
+    speakableSummary: `2026 open house guide for Summerlin buyers: NAR disclosure rules, what to expect at tours, and how to book a consultation with ${AGENT}—no signup form required.`,
+    faqs: [
+      {
+        question: 'Do I need a buyer agreement before an open house in 2026?',
+        answer: 'Open houses remain exempt from signing buyer representation before viewing. You may see disclosure forms at the door; representation is discussed when you are ready.',
+      },
+      {
+        question: 'How do I get the open house touring guide?',
+        answer: `Schedule a consultation on this page via Calendly or call ${PHONE}. Dr. Jan Duffy can share the guide during your appointment.`,
+      },
+    ],
+    relatedLinks: [
+      { href: '/open-houses', label: 'Weekend open houses' },
+      { href: '/book-tour', label: 'Book a tour' },
+      { href: '/resources/home-buying-guide', label: 'Home buying guide' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/schedule-consultation': {
+    speakableSummary: `Schedule a free real estate consultation with ${AGENT} at ${SITE}. Discuss buying, selling, or investing in Summerlin—choose a Calendly time online.`,
+    faqs: [
+      {
+        question: 'Is a consultation with Dr. Jan Duffy free?',
+        answer: 'Yes. Initial consultations are complimentary. Buyer or seller representation terms are explained before you sign any agreement.',
+      },
+      {
+        question: 'What should I prepare for a consultation?',
+        answer: 'Bring questions about neighborhoods, budget, timeline, and any listings you have seen. Pre-approval helps if you plan to buy soon.',
+      },
+    ],
+    relatedLinks: [
+      { href: '/book-tour', label: 'Book a private showing' },
+      { href: '/market-report', label: 'Market report' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/neighborhoods': {
+    speakableSummary: `Explore Summerlin West neighborhoods—from luxury The Ridges and Red Rock Country Club to family-friendly Summerlin Centre and 55+ Sun City—with guides from ${AGENT}.`,
+    faqs: [
+      {
+        question: 'How many neighborhoods are in Summerlin West?',
+        answer: 'Summerlin includes villages such as The Ridges, Red Rock Country Club, Summerlin Centre, Sun City Summerlin, The Trails, Willows, Mesa Ridge, Siena, and Regency.',
+      },
+      {
+        question: 'How do I compare Summerlin neighborhoods?',
+        answer: 'Use each neighborhood page for lifestyle and price context, then search MLS or call for a tailored tour plan.',
+      },
+    ],
+    relatedLinks: [
+      { href: '/neighborhoods/the-ridges', label: 'The Ridges' },
+      { href: '/neighborhoods/summerlin-centre', label: 'Summerlin Centre' },
+      { href: '/zip/89138', label: 'Zip 89138' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/amenity-map': {
+    speakableSummary: `Interactive amenity map near ${SITE} in Summerlin West—restaurants, parks, groceries, and services around ${GBP.address.street}—plus area map and showing scheduler.`,
+    faqs: [
+      {
+        question: 'What amenities are near Summerlin West?',
+        answer: 'Downtown Summerlin shopping, trails, parks, golf, medical offices, and dining cluster within a short drive of 89135–89144.',
+      },
+      {
+        question: 'How do I use the amenity map?',
+        answer: 'Toggle categories on the map to see nearby places. For home tours, book at /book-tour or call the office.',
+      },
+    ],
+    relatedLinks: [
+      { href: '/directions', label: 'Directions to our office' },
+      { href: '/resources/lifestyle-guide', label: 'Lifestyle guide' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/store-locations': {
+    speakableSummary: `${SITE} office at ${GBP.address.street}, ${GBP.address.locality}, NV ${GBP.address.postalCode}. View the map, hours, and book a visit with ${AGENT}.`,
+    faqs: [
+      {
+        question: 'Where is the Open House Market Place office?',
+        answer: `${GBP.name}, ${GBP.address.street}, ${GBP.address.locality}, ${GBP.address.region} ${GBP.address.postalCode}. Open daily 9 AM–5 PM per Google Business Profile.`,
+      },
+      {
+        question: 'Do I need an appointment to visit the office?',
+        answer: `Walk-ins welcome during business hours; scheduling at /book-tour ensures ${AGENT} is available for a focused consultation.`,
+      },
+    ],
+    relatedLinks: [
+      { href: '/directions', label: 'Get directions' },
+      { href: '/contact', label: 'Contact' },
+      ...CORE_LINKS,
+    ],
+  },
+  '/sitemap': {
+    speakableSummary: `HTML sitemap for ${SITE}: open houses, neighborhoods, buyer tools, builders, and legal pages for Summerlin West real estate.`,
+    faqs: [
+      {
+        question: 'Where is the XML sitemap for search engines?',
+        answer: 'Submit https://www.openhousemarketplace.com/sitemap.xml in Google Search Console for crawl coverage.',
+      },
+    ],
+    relatedLinks: [
+      { href: '/open-houses', label: 'Open houses' },
+      { href: '/neighborhoods', label: 'Neighborhoods' },
+      { href: '/contact', label: 'Contact' },
+    ],
+  },
+  '/disclaimer': {
+    speakableSummary: `Legal disclaimer for ${SITE} and MLS listing data provided by ${AGENT}. Verify all property, school, and HOA information independently.`,
+    faqs: [
+      {
+        question: 'Is MLS data on this site guaranteed accurate?',
+        answer: 'Listing status, price, and features can change without notice. Confirm all details with your agent and official sources before contracting.',
+      },
+      {
+        question: 'Who should I contact with legal questions about the site?',
+        answer: `Email ${GBP.email} or call ${PHONE}. For representation terms, schedule a consultation with ${AGENT}.`,
+      },
+    ],
+    relatedLinks: [
+      { href: '/terms-of-service', label: 'Terms of service' },
+      { href: '/privacy-policy', label: 'Privacy policy' },
+      { href: '/contact', label: 'Contact' },
+    ],
+  },
+  '/neighborhoods/the-ridges': neighborhoodContent(
+    'The Ridges',
+    'the-ridges',
+    '89135',
+    'luxury gated custom estates and Red Rock views'
+  ),
+  '/neighborhoods/red-rock-country-club': neighborhoodContent(
+    'Red Rock Country Club',
+    'red-rock-country-club',
+    '89135',
+    'golf course homes and guard-gated luxury'
+  ),
+  '/neighborhoods/summerlin-centre': neighborhoodContent(
+    'Summerlin Centre',
+    'summerlin-centre',
+    '89138',
+    'Downtown Summerlin shopping and family-friendly villages'
+  ),
+  '/neighborhoods/sun-city-summerlin': neighborhoodContent(
+    'Sun City Summerlin',
+    'sun-city-summerlin',
+    '89144',
+    '55+ active adult living with golf and recreation'
   ),
 }
 

--- a/docs/SEO-GEO-AEO-2026.md
+++ b/docs/SEO-GEO-AEO-2026.md
@@ -12,6 +12,10 @@ This site implements all three layers in one stack:
 
 NAP, hours, and service area: **[`config/gbp.ts`](../config/gbp.ts)** only.
 
+Brand palette (UI): **[`config/brand.ts`](../config/brand.ts)** — Tailwind utilities `brand-plum`, `brand-teal`, `brand-mint`, `brand-stone`, `brand-surface`.
+
+Per-page AEO blocks: **[`components/PageIndexingEnhancement.tsx`](../components/PageIndexingEnhancement.tsx)** + **[`config/indexing-pages.ts`](../config/indexing-pages.ts)** on every marketing URL in the sitemap.
+
 ---
 
 ## SEO (Google Search)

--- a/lib/brand-classes.ts
+++ b/lib/brand-classes.ts
@@ -1,0 +1,12 @@
+/**
+ * Reusable Tailwind class strings for Open House Market Place brand palette.
+ * @see config/brand.ts
+ */
+export const brandLinkClass = 'text-brand-teal hover:text-brand-plum font-medium transition-colors'
+export const brandLinkUnderlineClass =
+  'text-brand-teal font-semibold hover:text-brand-plum hover:underline transition-colors'
+export const brandHeroGradientClass = 'bg-gradient-to-r from-brand-teal to-brand-plum text-white'
+export const brandInfoBoxClass = 'rounded-lg border border-brand-mint bg-brand-mint/40 p-4 md:p-6'
+export const brandPrimaryButtonClass =
+  'inline-flex items-center justify-center rounded-lg bg-brand-teal px-4 py-2 font-semibold text-white transition-colors hover:bg-brand-plum'
+export const brandSpinnerBorderClass = 'border-2 border-brand-teal border-t-transparent'

--- a/styles/realscout-widgets.css
+++ b/styles/realscout-widgets.css
@@ -2,30 +2,30 @@
 realscout-advanced-search {
   --rs-as-button-text-color: #ffffff;
   --rs-as-background-color: transparent;
-  --rs-as-button-color: #dc2626;
+  --rs-as-button-color: #6399a3;
   --rs-as-widget-width: 100% !important;
   --rs-as-border-radius: 0.5rem;
   --rs-as-font-family: system-ui, -apple-system, sans-serif;
   --rs-as-input-height: 48px;
-  --rs-as-button-hover-color: #b91c1c;
+  --rs-as-button-hover-color: #4a3861;
 }
 .realscout-search-container {
   width: 100% !important;
 }
 realscout-advanced-search input {
-  border: 1px solid #d1d5db !important;
+  border: 1px solid #e5e7eb !important;
   border-radius: 0.5rem !important;
   padding: 0.75rem !important;
   font-size: 1rem !important;
 }
 realscout-advanced-search button {
-  background-color: #dc2626 !important;
+  background-color: #6399a3 !important;
   border-radius: 0.5rem !important;
   font-weight: 500 !important;
   transition: background-color 0.2s !important;
 }
 realscout-advanced-search button:hover {
-  background-color: #b91c1c !important;
+  background-color: #4a3861 !important;
 }
 @media (max-width: 640px) {
   realscout-advanced-search {
@@ -38,6 +38,6 @@ realscout-advanced-search button:hover {
   }
 }
 realscout-office-listings {
-  --rs-listing-divider-color: #0e64c8;
+  --rs-listing-divider-color: #6399a3;
   width: 100%;
 }

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -1,6 +1,14 @@
 @import 'tailwindcss';
 @import './realscout-widgets.css';
 
+@theme {
+  --color-brand-plum: #4a3861;
+  --color-brand-teal: #6399a3;
+  --color-brand-mint: #b8dad7;
+  --color-brand-stone: #ada3a1;
+  --color-brand-surface: #e5e7eb;
+}
+
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still
@@ -25,19 +33,19 @@
     --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --primary: 261 27% 30%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 174 35% 91%;
+    --secondary-foreground: 261 27% 30%;
+    --muted: 220 13% 91%;
+    --muted-foreground: 20 5% 46%;
+    --accent: 188 26% 51%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
+    --border: 174 35% 79%;
+    --input: 220 13% 91%;
+    --ring: 188 26% 51%;
     --radius: 0.5rem;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **SEO, GEO, and AEO** coverage for every URL in `MARKETING_SITEMAP_ROUTES` (41 pages) and rolls out the new **brand color palette** across core chrome and the homepage.

## SEO / GEO / AEO

- Extended [`config/indexing-pages.ts`](config/indexing-pages.ts) with 13 previously missing paths: `/`, `/open-houses`, `/open-house-guide`, `/schedule-consultation`, `/neighborhoods`, `/amenity-map`, `/store-locations`, `/sitemap`, `/disclaimer`, and four neighborhood guides (The Ridges, Red Rock CC, Summerlin Centre, Sun City).
- Added [`PageIndexingEnhancement`](components/PageIndexingEnhancement.tsx) to every marketing page that lacked it (16 page files).
- Each block includes: **speakable summary** (Speakable JSON-LD), **visible FAQs** + `FAQPage` schema where applicable, and **localized internal links**.

## Brand palette

| Token | Hex | Usage |
|-------|-----|--------|
| `brand-plum` | #4a3861 | Header/footer backgrounds, headings |
| `brand-teal` | #6399a3 | CTAs, links, accents |
| `brand-mint` | #b8dad7 | Borders, hovers, chips |
| `brand-stone` | #ada3a1 | Neutral accent (available) |
| `brand-surface` | #e5e7eb | Section backgrounds |

- [`config/brand.ts`](config/brand.ts) + [`styles/tailwind.css`](styles/tailwind.css) `@theme`
- Updated: SiteHeader, Footer, SummerlinOpenHouseWebsite hero/CTAs, open-house-guide hero, PageIndexingEnhancement chips
- shadcn CSS variables aligned to plum/teal

## Verify after deploy

1. Spot-check `/`, `/open-houses`, `/neighborhoods/the-ridges` — “Quick answers” + related links at bottom
2. Confirm header/footer use plum/teal (not legacy blue/red)
3. Rich Results Test on a neighborhood page FAQ
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9cbf83b-91ba-4ffd-ad1d-0f26a43dc1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9cbf83b-91ba-4ffd-ad1d-0f26a43dc1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

